### PR TITLE
Member 삭제 API 개발

### DIFF
--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
     /* 비즈니스 에러 */
     // 회사
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "회사 정보를 찾을 수 없습니다."),
-    COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다.");
+    COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/thisway/member/controller/MemberController.java
+++ b/src/main/java/org/thisway/member/controller/MemberController.java
@@ -2,6 +2,8 @@ package org.thisway.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,5 +24,12 @@ public class MemberController {
         memberService.registerMember(request);
 
         return ApiResponse.created();
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteMember(@PathVariable Long id) {
+        memberService.deleteMember(id);
+
+        return ApiResponse.noContent();
     }
 }

--- a/src/main/java/org/thisway/member/repository/MemberRepository.java
+++ b/src/main/java/org/thisway/member/repository/MemberRepository.java
@@ -3,5 +3,5 @@ package org.thisway.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.thisway.member.entity.Member;
 
-public interface MemberRepository extends JpaRepository<Member, Integer> {
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/org/thisway/member/service/MemberService.java
+++ b/src/main/java/org/thisway/member/service/MemberService.java
@@ -3,6 +3,9 @@ package org.thisway.member.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.thisway.common.BaseEntity;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
@@ -18,5 +21,12 @@ public class MemberService {
         Member member = request.toMember();
 
         memberRepository.save(member);
+    }
+
+    public void deleteMember(Long id) {
+        memberRepository.findById(id)
+                .filter(BaseEntity::isActive)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND))
+                .delete();
     }
 }

--- a/src/test/java/org/thisway/member/service/MemberServiceTest.java
+++ b/src/test/java/org/thisway/member/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package org.thisway.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
@@ -48,4 +51,31 @@ class MemberServiceTest {
         assertThat(savedMember.getPassword()).isEqualTo(request.password());
         assertThat(savedMember.getPhone()).isEqualTo(request.phone());
     }
+
+    @Test
+    @DisplayName("멤버가 정상적으로 삭제된다.")
+    void givenValidMemberId_whenDeleteMember_thenSuccessfulDelete() {
+        // given
+        Member member = MemberFixture.createMember();
+
+        // when
+        memberRepository.save(member);
+
+        memberService.deleteMember(member.getId());
+
+        // then
+        Member deletedMember = memberRepository.findById(member.getId()).orElse(null);
+        assertThat(deletedMember).isNotNull();
+        assertThat(deletedMember.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("없는 멤버를 삭제하려 하면 member not found exception이 발생한다.")
+    void givenNotFoundMemberId_whenDeleteMember_thenThrowNotFoundException() {
+        // when & then
+        CustomException e = assertThrows(CustomException.class, () -> memberService.deleteMember(1L));
+
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+    }
+
 }

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -1,6 +1,7 @@
 package org.thisway.member.support;
 
 import org.thisway.member.dto.request.MemberRegisterRequest;
+import org.thisway.member.entity.Member;
 
 public class MemberFixture {
 
@@ -12,5 +13,15 @@ public class MemberFixture {
                 "010-1234-5678",
                 "가입 메모"
         );
+    }
+
+    public static Member createMember() {
+        return Member.builder()
+                .name("홍길동")
+                .email("hong@example.com")
+                .password("Password123!")
+                .phone("010-1234-5678")
+                .memo("가입 메모")
+                .build();
     }
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #8 

### ✨ 반영 브랜치
feat/8 -> develop

### 📝 변경 사항
- Member 삭제 API 개발했습니다.
- MemberRepository의 Member Id 값 타입 `Integer` -> `Long`으로 수정했습니다!

### ➕ 추가 메모
- #16

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![Test Code 작동 결과](https://github.com/user-attachments/assets/c31443a4-b76a-4720-9901-8a54b7c03b2b)

