### PR TITLE
Member 전체 조회 API 개발

### DIFF
--- a/src/main/java/org/thisway/member/controller/MemberController.java
+++ b/src/main/java/org/thisway/member/controller/MemberController.java
@@ -1,6 +1,8 @@
 package org.thisway.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.thisway.common.ApiResponse;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
+import org.thisway.member.dto.response.MembersResponse;
 import org.thisway.member.service.MemberService;
 
 @RestController
@@ -25,6 +28,12 @@ public class MemberController {
     public ApiResponse<MemberResponse> getMemberDetail(@PathVariable Long id) {
         return ApiResponse.ok(memberService.getMemberDetail(id));
     }
+
+    @GetMapping
+    public ApiResponse<MembersResponse> getMembers(@PageableDefault Pageable pageable) {
+        return ApiResponse.ok(memberService.getMembers(pageable));
+    }
+
 
     @PostMapping
     public ApiResponse<Void> registerMember(@RequestBody @Validated MemberRegisterRequest request) {

--- a/src/main/java/org/thisway/member/dto/response/MembersResponse.java
+++ b/src/main/java/org/thisway/member/dto/response/MembersResponse.java
@@ -1,0 +1,16 @@
+package org.thisway.member.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.Page;
+import org.thisway.member.entity.Member;
+
+public record MembersResponse(
+        @JsonProperty(value = "members")
+        Page<MemberResponse> memberResponses
+) {
+
+    public static MembersResponse from(Page<Member> members) {
+        return new MembersResponse(members.map(MemberResponse::from));
+    }
+}

--- a/src/main/java/org/thisway/member/repository/MemberRepository.java
+++ b/src/main/java/org/thisway/member/repository/MemberRepository.java
@@ -1,7 +1,11 @@
 package org.thisway.member.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.thisway.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Page<Member> findAllByActiveTrue(Pageable pageable);
 }

--- a/src/main/java/org/thisway/member/service/MemberService.java
+++ b/src/main/java/org/thisway/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.thisway.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thisway.common.BaseEntity;
@@ -8,6 +9,7 @@ import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
+import org.thisway.member.dto.response.MembersResponse;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
 
@@ -24,6 +26,11 @@ public class MemberService {
                 .filter(BaseEntity::isActive)
                 .map(MemberResponse::from)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public MembersResponse getMembers(Pageable pageable) {
+        return MembersResponse.from(memberRepository.findAllByActiveTrue(pageable));
     }
 
     public void registerMember(MemberRegisterRequest request) {

--- a/src/test/java/org/thisway/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/thisway/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package org.thisway.member.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -12,10 +13,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestConstructor;
@@ -27,6 +30,7 @@ import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
+import org.thisway.member.dto.response.MembersResponse;
 import org.thisway.member.service.MemberService;
 import org.thisway.member.support.MemberFixture;
 
@@ -89,6 +93,34 @@ class MemberControllerTest {
                 responseBody, new TypeReference<ApiResponse<MemberResponse>>() {}
         );
         assertThat(response.status()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @Disabled
+    // todo: PageResponse 구조 결정 후 코드 및 주석 변경 or Disable 해제
+    void 멤버_전체_조회가_정상적으로_되었을_때_ok_응답과_함께_정상적으로_데이터를_조회할_수_있다() throws Exception {
+        // when
+        MembersResponse expectResponse = MemberFixture.createMembersResponse(2);
+        when(memberService.getMembers(any(Pageable.class)))
+                .thenReturn(expectResponse);
+
+        MvcResult mvcResult = mockMvc.perform(
+                        get("/api/members")
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        // then
+        String responseBody = mvcResult.getResponse().getContentAsString();
+        ApiResponse<MembersResponse> response = objectMapper.readValue(
+                responseBody, new TypeReference<ApiResponse<MembersResponse>>() {}
+        );
+        assertThat(response.status()).isEqualTo(HttpStatus.OK.value());
+
+        MembersResponse membersResponse = response.data();
+        assertThat(membersResponse).isNotNull();
+        assertThat(membersResponse.memberResponses()).hasSize(2);
     }
 
     @Test

--- a/src/test/java/org/thisway/member/service/MemberServiceTest.java
+++ b/src/test/java/org/thisway/member/service/MemberServiceTest.java
@@ -10,12 +10,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
+import org.thisway.member.dto.response.MembersResponse;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
 import org.thisway.member.support.MemberFixture;
@@ -64,6 +66,26 @@ class MemberServiceTest {
 
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
         // then
+    }
+
+    @Test
+    void 멤버가_페이징_정보에_맞게_정상적으로_조회된다() {
+        // given
+        List<Member> members = List.of(
+                MemberFixture.createMember(),
+                MemberFixture.createMember(),
+                MemberFixture.createMember(),
+                MemberFixture.createMember()
+        );
+
+        // when
+        memberRepository.saveAll(members);
+        MembersResponse membersResponse = memberService.getMembers(PageRequest.of(0, 2));
+
+        // then
+        assertThat(membersResponse.memberResponses().getTotalElements()).isEqualTo(members.size());
+        assertThat(membersResponse.memberResponses().getNumberOfElements()).isEqualTo(2);
+        assertThat(membersResponse.memberResponses().getSize()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -1,7 +1,13 @@
 package org.thisway.member.support;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
+import org.thisway.member.dto.response.MembersResponse;
 import org.thisway.member.entity.Member;
 
 public class MemberFixture {
@@ -34,5 +40,20 @@ public class MemberFixture {
                 "010-1234-5678",
                 "가입 메모"
         );
+    }
+
+    public static MembersResponse createMembersResponse(int size) {
+        List<Member> members = new ArrayList<>();
+        for (int i = 1; i <= size; i++) {
+            members.add(createMember());
+        }
+
+        Page<Member> page = new PageImpl<>(
+                members,
+                PageRequest.of(0, size),
+                size
+        );
+
+        return MembersResponse.from(page);
     }
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #21 

### ✨ 반영 브랜치
feat/21 -> develop

### 📝 변경 사항

#### 기능 구현
- MemberRepository: 전체 조회 메서드 추가
- MemberController: 전체 조회 end-point 메서드 추가
- MemberService: 전체 조회 기능 추가

#### 테스트
- MemberControllerTest: 전체 조회 정상 작동 테스트 추가
  - ⚠️ Page 타입 역직렬화 문제로 Disable 처리
- MemberServiceTest: 전체 조회 정상 작동 테스트 추가

### ➕ 추가 메모
- 테스트 Disable 처리 및 todo 주석 처리

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![테스트 코드 스크린샷](https://github.com/user-attachments/assets/ccc0e39b-68d7-401a-9b42-185a1f13c074)
