### PR TITLE
Member 컬럼의 제약조건 및 검증 추가

### DIFF
--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
+    MEMBER_INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 핸드폰 번호입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
-    MEMBER_ALREADY_EXIST_BY_EMAIL(HttpStatus.CONFLICT, "이미 이메일의 사용자입니다."),
+    MEMBER_ALREADY_EXIST_BY_EMAIL(HttpStatus.CONFLICT, "이미 등록된 이메일입니다."),
     MEMBER_INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 핸드폰 번호입니다."),
     ;
 

--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
+    MEMBER_ALREADY_EXIST_BY_EMAIL(HttpStatus.CONFLICT, "이미 이메일의 사용자입니다."),
     MEMBER_INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않은 핸드폰 번호입니다."),
     ;
 

--- a/src/main/java/org/thisway/member/dto/response/MemberResponse.java
+++ b/src/main/java/org/thisway/member/dto/response/MemberResponse.java
@@ -15,7 +15,7 @@ public record MemberResponse(
                 member.getId(),
                 member.getName(),
                 member.getEmail(),
-                member.getPhone(),
+                member.getPhoneValue(),
                 member.getMemo()
         );
     }

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -1,6 +1,8 @@
 package org.thisway.member.entity;
 
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,8 +25,9 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
-    private String phone;
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "phone", nullable = false))
+    private PhoneNumber phone;
 
     @Column(nullable = false)
     private String memo;
@@ -40,7 +43,11 @@ public class Member extends BaseEntity {
         this.name = name;
         this.email = email;
         this.password = password;
-        this.phone = phone;
+        this.phone = new PhoneNumber(phone);
         this.memo = memo;
+    }
+
+    public String getPhoneValue() {
+        return phone.getValue();
     }
 }

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/org/thisway/member/entity/PhoneNumber.java
+++ b/src/main/java/org/thisway/member/entity/PhoneNumber.java
@@ -1,0 +1,29 @@
+package org.thisway.member.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class PhoneNumber {
+
+    public static final String VALID_PHONE_NUMBER_REGEX = "^010\\d{8}$";
+
+    private String value;
+
+    public PhoneNumber(String value) {
+        validateValue(value);
+        this.value = value;
+    }
+
+    private void validateValue(String value) {
+        if (value == null || !value.matches(VALID_PHONE_NUMBER_REGEX)) {
+            throw new CustomException(ErrorCode.MEMBER_INVALID_PHONE_NUMBER);
+        }
+    }
+}

--- a/src/main/java/org/thisway/member/repository/MemberRepository.java
+++ b/src/main/java/org/thisway/member/repository/MemberRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.thisway.member.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/org/thisway/member/service/MemberService.java
+++ b/src/main/java/org/thisway/member/service/MemberService.java
@@ -27,6 +27,10 @@ public class MemberService {
     }
 
     public void registerMember(MemberRegisterRequest request) {
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_EXIST_BY_EMAIL);
+        }
+
         Member member = request.toMember();
 
         memberRepository.save(member);

--- a/src/test/java/org/thisway/member/entity/PhoneNumberTest.java
+++ b/src/test/java/org/thisway/member/entity/PhoneNumberTest.java
@@ -1,0 +1,32 @@
+package org.thisway.member.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+
+class PhoneNumberTest {
+
+    @Test
+    void 유효한_휴대폰_번호는_정상적으로_생성된다() {
+        assertThatCode(() -> new PhoneNumber("01012345678"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 유효하지_않은_휴대폰_번호_생성시_예외가_발생한다() {
+        CustomException e1 = assertThrows(CustomException.class,
+                () -> new PhoneNumber("010-1234-5678"));
+        CustomException e2 = assertThrows(CustomException.class,
+                () -> new PhoneNumber("+82-10-1234-5678"));
+        CustomException e3 = assertThrows(CustomException.class,
+                () -> new PhoneNumber("0212345678"));
+
+        assertThat(e1.getErrorCode()).isEqualTo(ErrorCode.MEMBER_INVALID_PHONE_NUMBER);
+        assertThat(e2.getErrorCode()).isEqualTo(ErrorCode.MEMBER_INVALID_PHONE_NUMBER);
+        assertThat(e3.getErrorCode()).isEqualTo(ErrorCode.MEMBER_INVALID_PHONE_NUMBER);
+    }
+}

--- a/src/test/java/org/thisway/member/service/MemberServiceTest.java
+++ b/src/test/java/org/thisway/member/service/MemberServiceTest.java
@@ -46,7 +46,7 @@ class MemberServiceTest {
         // then
         assertThat(memberResponse.id()).isEqualTo(member.getId());
         assertThat(memberResponse.email()).isEqualTo(member.getEmail());
-        assertThat(memberResponse.phone()).isEqualTo(member.getPhone());
+        assertThat(memberResponse.phone()).isEqualTo(member.getPhoneValue());
     }
 
     @Test
@@ -83,7 +83,7 @@ class MemberServiceTest {
         assertThat(savedMember.getId()).isNotNull();
         assertThat(savedMember.getEmail()).isEqualTo(request.email());
         assertThat(savedMember.getPassword()).isEqualTo(request.password());
-        assertThat(savedMember.getPhone()).isEqualTo(request.phone());
+        assertThat(savedMember.getPhoneValue()).isEqualTo(request.phone());
     }
 
     @Test

--- a/src/test/java/org/thisway/member/service/MemberServiceTest.java
+++ b/src/test/java/org/thisway/member/service/MemberServiceTest.java
@@ -87,6 +87,20 @@ class MemberServiceTest {
     }
 
     @Test
+    @DisplayName("멤버 등록이 정상적으로 등록된다.")
+    void 멤버_등록시_존재하는_이메일의_회원일_경우_예외가_발생한다() {
+        // given
+        String email = "hong@example.com";
+        MemberRegisterRequest request = MemberFixture.createMemberRegisterRequestWithEmail(email);
+
+        // when & then
+        memberRepository.save(MemberFixture.createMemberWithEmail(email));
+        CustomException e = assertThrows(CustomException.class, () -> memberService.registerMember(request));
+
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.MEMBER_ALREADY_EXIST_BY_EMAIL);
+    }
+
+    @Test
     @DisplayName("멤버가 정상적으로 삭제된다.")
     void givenValidMemberId_whenDeleteMember_thenSuccessfulDelete() {
         // given

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -16,10 +16,30 @@ public class MemberFixture {
         );
     }
 
+    public static MemberRegisterRequest createMemberRegisterRequestWithEmail(String email) {
+        return new MemberRegisterRequest(
+                "홍길동",
+                email,
+                "Password123!",
+                "01012345678",
+                "가입 메모"
+        );
+    }
+
     public static Member createMember() {
         return Member.builder()
                 .name("홍길동")
                 .email("hong@example.com")
+                .password("Password123!")
+                .phone("01012345678")
+                .memo("가입 메모")
+                .build();
+    }
+
+    public static Member createMemberWithEmail(String email) {
+        return Member.builder()
+                .name("홍길동")
+                .email(email)
                 .password("Password123!")
                 .phone("01012345678")
                 .memo("가입 메모")

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -11,7 +11,7 @@ public class MemberFixture {
                 "홍길동",
                 "hong@example.com",
                 "Password123!",
-                "010-1234-5678",
+                "01012345678",
                 "가입 메모"
         );
     }
@@ -21,7 +21,7 @@ public class MemberFixture {
                 .name("홍길동")
                 .email("hong@example.com")
                 .password("Password123!")
-                .phone("010-1234-5678")
+                .phone("01012345678")
                 .memo("가입 메모")
                 .build();
     }
@@ -31,7 +31,7 @@ public class MemberFixture {
                 1L,
                 "홍길동",
                 "hong@example.com",
-                "010-1234-5678",
+                "01012345678",
                 "가입 메모"
         );
     }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #15 

### ✨ 반영 브랜치
- feat/15 -> develop

### 📝 변경 사항
#### 휴대폰 번호 검증을 위한 Embeddable 타입 추가
- 기능 추가
  - 휴대폰 번호가 '010'으로 시작하고 뒤에 8자리 숫자가 오는지 검증하는 로직 추가
  - 검증 로직을 PhoneNumber 생성자에 적용하여 불변성 보장
  - Member 엔티티의 phone 필드를 Embeddable 타입인PhoneNumber로 변경하고 관련 코드 수정
-  테스트 추가
  - PhoneNumber
     - 유효한 휴대폰 번호 정상 생성 테스트
     - 유효하지 않은 휴대폰 번호 예외 발생 테스트

 
#### Member email 컬럼에 unique 제약 조건 추가
- 기능 추가
  - Member 엔티티의 email 필드에 unique 제약 조건 추가
  - 중복된 email 등록 시 예외가 발생하도록 서비스 로직에 중복 체크 로직 추가
- 테스트 추가
  - MemberServiceTest
  - 중복된 email로 Member 등록 시 예외 발생 테스트 추가

### ➕ 추가 메모

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![테스트 결과 스크린샷](https://github.com/user-attachments/assets/d336e58f-72ba-4b37-9309-3b31612e5328)

