### PR TITLE
Member-Company 연관관계 설정 및 등록 로직 수정

### DIFF
--- a/src/main/java/org/thisway/member/controller/MemberController.java
+++ b/src/main/java/org/thisway/member/controller/MemberController.java
@@ -29,6 +29,7 @@ public class MemberController {
         return ApiResponse.ok(memberService.getMemberDetail(id));
     }
 
+    // todo: 업체 최고 담당자가 조회할 경우 특정 업체 Member만 조회 가능하도록 변경 (인증 기능 추가 후)
     @GetMapping
     public ApiResponse<MembersResponse> getMembers(@PageableDefault Pageable pageable) {
         return ApiResponse.ok(memberService.getMembers(pageable));

--- a/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
@@ -2,9 +2,13 @@ package org.thisway.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.thisway.company.entity.Company;
 import org.thisway.member.entity.Member;
 
 public record MemberRegisterRequest(
+
+        @NotNull
+        Long companyId,
 
         @NotBlank
         String name,
@@ -22,8 +26,9 @@ public record MemberRegisterRequest(
         String memo
 ) {
 
-    public Member toMember() {
+    public Member toMember(Company company) {
         return Member.builder()
+                .company(company)
                 .name(name)
                 .email(email)
                 .password(password)

--- a/src/main/java/org/thisway/member/dto/response/MemberResponse.java
+++ b/src/main/java/org/thisway/member/dto/response/MemberResponse.java
@@ -4,6 +4,7 @@ import org.thisway.member.entity.Member;
 
 public record MemberResponse(
         Long id,
+        Long companyId,
         String name,
         String email,
         String phone,
@@ -13,6 +14,7 @@ public record MemberResponse(
     public static MemberResponse from(Member member) {
         return new MemberResponse(
                 member.getId(),
+                member.getCompany().getId(),
                 member.getName(),
                 member.getEmail(),
                 member.getPhoneValue(),

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -4,17 +4,25 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.thisway.common.BaseEntity;
+import org.thisway.company.entity.Company;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 // todo: 인증/인가 구현 후 역할 컬럼 추가
 public class Member extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_id", nullable = false)
+    private Company company;
 
     @Column(nullable = false)
     private String name;
@@ -34,12 +42,14 @@ public class Member extends BaseEntity {
 
     @Builder
     public Member(
+            Company company,
             String name,
             String email,
             String password,
             String phone,
             String memo
     ) {
+        this.company = company;
         this.name = name;
         this.email = email;
         this.password = password;

--- a/src/main/java/org/thisway/member/service/MemberService.java
+++ b/src/main/java/org/thisway/member/service/MemberService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.thisway.common.BaseEntity;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
+import org.thisway.company.entity.Company;
+import org.thisway.company.repository.CompanyRepository;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
 import org.thisway.member.dto.response.MembersResponse;
@@ -19,6 +21,7 @@ import org.thisway.member.repository.MemberRepository;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final CompanyRepository companyRepository;
 
     @Transactional(readOnly = true)
     public MemberResponse getMemberDetail(Long id) {
@@ -38,7 +41,11 @@ public class MemberService {
             throw new CustomException(ErrorCode.MEMBER_ALREADY_EXIST_BY_EMAIL);
         }
 
-        Member member = request.toMember();
+        Company company = companyRepository.findById(request.companyId())
+                .filter(BaseEntity::isActive)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+        Member member = request.toMember(company);
 
         memberRepository.save(member);
     }

--- a/src/test/java/org/thisway/company/support/CompanyFixture.java
+++ b/src/test/java/org/thisway/company/support/CompanyFixture.java
@@ -1,0 +1,18 @@
+package org.thisway.company.support;
+
+import org.thisway.company.entity.Company;
+
+public class CompanyFixture {
+
+    public static Company createCompany() {
+        return Company.builder()
+                .name("name")
+                .crn("crn")
+                .contact("contact")
+                .addrRoad("addrRoad")
+                .addrDetail("addrDetail")
+                .memo("memo")
+                .gpsCycle(60)
+                .build();
+    }
+}

--- a/src/test/java/org/thisway/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/thisway/member/controller/MemberControllerTest.java
@@ -127,7 +127,7 @@ class MemberControllerTest {
     @DisplayName("멤버 등록이 정상적으로 되었을 때, created 응답을 한다.")
     void givenValidRequest_whenRegisterMember_thenReturnsCreatedStatus() throws Exception {
         // given
-        MemberRegisterRequest request = MemberFixture.createMemberRegisterRequest();
+        MemberRegisterRequest request = MemberFixture.createMemberRegisterRequestWithCompanyId(1L);
 
         // when
         MvcResult mvcResult = mockMvc.perform(

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.thisway.company.entity.Company;
+import org.thisway.company.support.CompanyFixture;
 import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
 import org.thisway.member.dto.response.MembersResponse;
@@ -12,8 +14,9 @@ import org.thisway.member.entity.Member;
 
 public class MemberFixture {
 
-    public static MemberRegisterRequest createMemberRegisterRequest() {
+    public static MemberRegisterRequest createMemberRegisterRequestWithCompanyId(long companyId) {
         return new MemberRegisterRequest(
+                companyId,
                 "홍길동",
                 "hong@example.com",
                 "Password123!",
@@ -22,8 +25,9 @@ public class MemberFixture {
         );
     }
 
-    public static MemberRegisterRequest createMemberRegisterRequestWithEmail(String email) {
+    public static MemberRegisterRequest createMemberRegisterRequestWithCompanyIdAndEmail(long companyId, String email) {
         return new MemberRegisterRequest(
+                companyId,
                 "홍길동",
                 email,
                 "Password123!",
@@ -32,8 +36,9 @@ public class MemberFixture {
         );
     }
 
-    public static Member createMember() {
+    public static Member createMember(Company company) {
         return Member.builder()
+                .company(company)
                 .name("홍길동")
                 .email("hong@example.com")
                 .password("Password123!")
@@ -42,8 +47,9 @@ public class MemberFixture {
                 .build();
     }
 
-    public static Member createMemberWithEmail(String email) {
+    public static Member createMemberWithEmail(Company company, String email) {
         return Member.builder()
+                .company(company)
                 .name("홍길동")
                 .email(email)
                 .password("Password123!")
@@ -55,6 +61,7 @@ public class MemberFixture {
     public static MemberResponse createMemberResponse(long id) {
         return new MemberResponse(
                 1L,
+                1L,
                 "홍길동",
                 "hong@example.com",
                 "01012345678",
@@ -65,7 +72,7 @@ public class MemberFixture {
     public static MembersResponse createMembersResponse(int size) {
         List<Member> members = new ArrayList<>();
         for (int i = 1; i <= size; i++) {
-            members.add(createMember());
+            members.add(createMember(CompanyFixture.createCompany()));
         }
 
         Page<Member> page = new PageImpl<>(


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #16 

### ✨ 반영 브랜치
feat/16 -> develop

### 📝 변경 사항
- Member 엔티티에 Company 연관관계(`@ManyToOne`) 설정
- Company 정보를 Member 조회 응답 DTO에 포함
- Member 등록 시 Company ID를 함께 받도록 요청 구조 및 생성 로직 수정

### ➕ 추가 메모
- 현재 MemberService에서 Company를 조회할 때 CompanyRepository에서 직접 조회하고 있습니다.
  - CompanyService를 이용하려 했지만 Response DTO로 변환 처리 과정 포함으로 Entity 이용 불가

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![테스트 스크린샷](https://github.com/user-attachments/assets/87409a4e-7496-4b93-bc74-1d76caec78a0)
