### PR TITLE
이메일 인증 코드 발송 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### custom ###
 **/application.yml
 **/db-environment.yml
+**/application-dev.yml
 gradle.properties
 build.local.gradle
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/thisway/auth/controller/AuthController.java
+++ b/src/main/java/org/thisway/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package org.thisway.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.thisway.auth.dto.request.SendVerifyCodeRequest;
+import org.thisway.auth.service.EmailVerificationService;
+import org.thisway.common.ApiResponse;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/verify-code")
+    public ApiResponse<Void> sendVerifyCode(@RequestBody SendVerifyCodeRequest request) {
+        emailVerificationService.sendVerifyCode(request.email());
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/org/thisway/auth/dto/VerificationEntry.java
+++ b/src/main/java/org/thisway/auth/dto/VerificationEntry.java
@@ -1,0 +1,8 @@
+package org.thisway.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VerificationEntry(@NotBlank String code, @NotBlank long expiryTime) {
+}

--- a/src/main/java/org/thisway/auth/dto/VerificationPayload.java
+++ b/src/main/java/org/thisway/auth/dto/VerificationPayload.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotBlank;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record VerificationEntry(@NotBlank String code, @NotBlank long expiryTime) {
+public record VerificationPayload(@NotBlank String code, @NotBlank long expiryTime) {
 }

--- a/src/main/java/org/thisway/auth/dto/request/SendVerifyCodeRequest.java
+++ b/src/main/java/org/thisway/auth/dto/request/SendVerifyCodeRequest.java
@@ -1,0 +1,7 @@
+package org.thisway.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SendVerifyCodeRequest(@NotBlank String email) {
+
+}

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -1,0 +1,213 @@
+package org.thisway.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thisway.auth.dto.VerificationEntry;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+
+import java.security.SecureRandom;
+import java.text.DecimalFormat;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailVerificationService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final JavaMailSender javaMailSender;
+
+    @Value("${custom.auth-code-expiration-millis}")
+    private long authCodeExpirationMills;
+
+    public void sendVerifyCode(String email) {
+        // 이메일 regex 처리 예정.
+        // Member find 로직 추가 예정.
+
+        String code = generateVerifyCode();
+
+        VerificationEntry verificationEntry = new VerificationEntry(code, System.currentTimeMillis() + authCodeExpirationMills);
+        storeCode(email, verificationEntry);
+
+        sendMail(email, code);
+    }
+
+    public String generateVerifyCode() {
+        DecimalFormat CODE_FORMAT = new DecimalFormat("000000");
+        SecureRandom secureRandom = new SecureRandom();
+        return CODE_FORMAT.format(secureRandom.nextInt(900000) + 100000);
+    }
+
+    public void storeCode(String email, VerificationEntry verificationEntry) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String json = objectMapper.writeValueAsString(verificationEntry);
+            redisTemplate.opsForValue().set(email, json, authCodeExpirationMills, TimeUnit.MILLISECONDS);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.SERVER_ERROR);
+        }
+    }
+
+    public void sendMail(String email, String code) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("ThisWay 비밀번호 변경 인증 메일");
+
+            mimeMessageHelper.setText(generateEmailContent(code), true);
+            javaMailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new CustomException(ErrorCode.SERVER_ERROR);
+        }
+    }
+
+    public String generateEmailContent(String code) {
+        String html = String.format("""
+                <!DOCTYPE html>
+                <html lang="ko">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>이메일 인증 코드</title>
+                    <style>
+                        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto+Mono:wght@700&display=swap');
+                
+                        body {
+                            font-family: 'Inter', sans-serif;
+                            margin: 0;
+                            padding: 0;
+                            background-color: #F9FAFB;
+                            color: #111827;
+                        }
+                
+                        .container {
+                            max-width: 600px;
+                            margin: 0 auto;
+                            background-color: #FFFFFF;
+                            padding: 40px;
+                        }
+                
+                        .header {
+                            text-align: center;
+                            margin-bottom: 32px;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            gap: 12px;
+                        }
+                
+                        .logo {
+                            width: 40px;
+                            height: 40px;
+                        }
+                
+                        .service-name {
+                            font-size: 24px;
+                            font-weight: 700;
+                            margin: 0;
+                        }
+                
+                        .content {
+                            margin-bottom: 32px;
+                        }
+                
+                        .title {
+                            font-size: 20px;
+                            font-weight: 700;
+                            text-align: center;
+                            margin-bottom: 8px;
+                        }
+                
+                        .subtitle {
+                            font-size: 16px;
+                            color: #4B5563;
+                            text-align: center;
+                            margin-bottom: 24px;
+                        }
+                
+                        .code-container {
+                            background-color: #F3F4F6;
+                            border-radius: 8px;
+                            padding: 24px;
+                            text-align: center;
+                            margin-bottom: 16px;
+                        }
+                
+                        .code {
+                            font-family: 'Roboto Mono', monospace;
+                            font-size: 32px;
+                            font-weight: 700;
+                            letter-spacing: 4px;
+                        }
+                
+                        .expiry {
+                            font-size: 14px;
+                            color: #6B7280;
+                            text-align: center;
+                            margin-bottom: 24px;
+                        }
+                
+                        .divider {
+                            height: 1px;
+                            background-color: #E5E7EB;
+                            margin: 24px 0 16px 0;
+                        }
+                
+                        .footer {
+                            color: #9CA3AF;
+                            font-size: 14px;
+                            text-align: center;
+                        }
+                
+                        .footer p {
+                            margin: 4px 0;
+                        }
+                    </style>
+                </head>
+                <body>
+                    <div class="container">
+                        <div class="header">
+                            <svg class="logo" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <rect width="40" height="40" rx="8" fill="#4F46E5"/>
+                                <path d="M20 10L28 18L20 26L12 18L20 10Z" fill="white"/>
+                            </svg>
+                            <h1 class="service-name">ThisWay</h1>
+                        </div>
+                
+                        <div class="content">
+                            <h2 class="title">이메일 인증 코드</h2>
+                            <p class="subtitle">아래 인증 코드를 입력하여 이메일 인증을 완료해 주세요.</p>
+                
+                            <div class="code-container">
+                                <div class="code">%s</div>
+                            </div>
+                            <p class="expiry">인증 코드는 10분 동안 유효합니다.</p>
+                
+                        </div>
+                
+                        <div class="divider"></div>
+                
+                        <div class="footer">
+                            <p>본 이메일은 발신 전용이며, 회신하실 수 없습니다.</p>
+                            <p>© 2025 Thisway. All rights reserved.</p>
+                        </div>
+                    </div>
+                </body>
+                </html>
+                """, code);
+
+        return html;
+    }
+}

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -36,7 +36,7 @@ public class EmailVerificationService {
         // todo: 이메일 regex 처리 예정.
 
         // todo: ErrorCode 논의 후 변경 예정.
-        memberRepository.findByEmail(email)
+        memberRepository.findByEmailAndActiveTrue(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         String code = generateVerifyCode();

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -4,16 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thisway.auth.dto.VerificationEntry;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
+import org.thisway.member.repository.MemberRepository;
 
 import java.security.SecureRandom;
 import java.text.DecimalFormat;
@@ -21,8 +20,9 @@ import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class EmailVerificationService {
+
+    private final MemberRepository memberRepository;
 
     private final StringRedisTemplate redisTemplate;
     private final JavaMailSender javaMailSender;
@@ -32,7 +32,10 @@ public class EmailVerificationService {
 
     public void sendVerifyCode(String email) {
         // 이메일 regex 처리 예정.
-        // Member find 로직 추가 예정.
+
+        // Member find 로직 추가 예정
+        memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         String code = generateVerifyCode();
 

--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
     /* 비즈니스 에러 */
     // 회사
     COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "회사 정보를 찾을 수 없습니다."),
-    COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다.");
+    COMPANY_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 회사입니다."),
+
+    // 멤버
+    INVALID_VERIFY_CODE(HttpStatus.BAD_REQUEST, "잘못된 인증 코드입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/org/thisway/config/smtp/MailConfig.java
+++ b/src/main/java/org/thisway/config/smtp/MailConfig.java
@@ -33,10 +33,10 @@ public class MailConfig {
     @Bean
     public JavaMailSender mailSender() {
         JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
-        mailSender.setHost(host.trim());
+        mailSender.setHost(host);
         mailSender.setPort(port);
-        mailSender.setUsername(username.trim());
-        mailSender.setPassword(password.trim());
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
         mailSender.setDefaultEncoding("UTF-8");
 
         Properties props = new Properties();

--- a/src/main/java/org/thisway/config/smtp/MailConfig.java
+++ b/src/main/java/org/thisway/config/smtp/MailConfig.java
@@ -1,0 +1,50 @@
+package org.thisway.config.smtp;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Slf4j
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttls;
+
+    @Bean
+    public JavaMailSender mailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host.trim());
+        mailSender.setPort(port);
+        mailSender.setUsername(username.trim());
+        mailSender.setPassword(password.trim());
+        mailSender.setDefaultEncoding("UTF-8");
+
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttls);
+
+        mailSender.setJavaMailProperties(props);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/org/thisway/member/repository/MemberRepository.java
+++ b/src/main/java/org/thisway/member/repository/MemberRepository.java
@@ -8,7 +8,7 @@ import org.thisway.member.entity.Member;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndActiveTrue(String email);
 
     Page<Member> findAllByActiveTrue(Pageable pageable);
 

--- a/src/main/java/org/thisway/member/repository/MemberRepository.java
+++ b/src/main/java/org/thisway/member/repository/MemberRepository.java
@@ -3,5 +3,8 @@ package org.thisway.member.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.thisway.member.entity.Member;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByEmail(String email);
 }

--- a/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package org.thisway.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestConstructor;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.thisway.auth.dto.request.SendVerifyCodeRequest;
@@ -18,6 +18,8 @@ import org.thisway.common.ApiResponse;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
 import org.thisway.member.support.MemberFixture;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -34,7 +36,6 @@ public class AuthControllerTest {
     private final MockMvc mockMvc;
     private final ObjectMapper objectMapper;
 
-    @MockitoBean
     private final MemberRepository memberRepository;
 
     @BeforeEach
@@ -84,7 +85,10 @@ public class AuthControllerTest {
     @Test
     @DisplayName("이메일 인증 코드 요청 시 비활성화 상태의 이메일을 입력하면, not_found 응답을 한다.")
     void givenInactiveEmail_whenSendVerifyCode_thenReturnNotFoundStatus() throws Exception {
-        mockMvc.perform(delete("/api/members/1"));
+        Member member = memberRepository.findByEmailAndActiveTrue("hong@example.com").orElse(null);
+        member.delete();
+        memberRepository.save(member);
+
         SendVerifyCodeRequest request = new SendVerifyCodeRequest("hong@example.com");
 
         MvcResult mvcResult = mockMvc.perform(

--- a/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
@@ -1,0 +1,86 @@
+package org.thisway.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.thisway.auth.dto.request.SendVerifyCodeRequest;
+import org.thisway.common.ApiResponse;
+import org.thisway.member.entity.Member;
+import org.thisway.member.repository.MemberRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+public class AuthControllerTest {
+
+    private final MockMvc mockMvc;
+    private final ObjectMapper objectMapper;
+
+    private final MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+        memberRepository.save(Member.builder()
+                .name("홍길동")
+                .email("abc@example.com")
+                .password("password1234")
+                .phone("010-1234-5678")
+                .memo("메모메모")
+                .build());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 전송에 성공했을 때, ok 응답을 한다.")
+    void givenValidEmail_whenSendVerifyCode_thenReturnOkStatus() throws Exception {
+        SendVerifyCodeRequest request = new SendVerifyCodeRequest("abc@example.com");
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/api/auth/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString();
+        ApiResponse<?> response = objectMapper.readValue(responseBody, ApiResponse.class);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 요청 시 존재하지 않는 이메일을 입력하면, not_found 응답을 한다.")
+    void givenInvalidEmail_whenSendVerifyCode_thenReturnNotFoundStatus() throws Exception {
+        SendVerifyCodeRequest request = new SendVerifyCodeRequest("1234@example.com");
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/api/auth/verify-code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        String responseBody = mvcResult.getResponse().getContentAsString();
+        ApiResponse<?> response = objectMapper.readValue(responseBody, ApiResponse.class);
+        assertThat(response.status()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+}

--- a/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.thisway.auth.dto.request.SendVerifyCodeRequest;
@@ -33,6 +34,7 @@ public class AuthControllerTest {
     private final MockMvc mockMvc;
     private final ObjectMapper objectMapper;
 
+    @MockitoBean
     private final MemberRepository memberRepository;
 
     @BeforeEach
@@ -80,7 +82,7 @@ public class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("이메일 인증 코드 요청 시 존재하지 않는 이메일을 입력하면, not_found 응답을 한다.")
+    @DisplayName("이메일 인증 코드 요청 시 비활성화 상태의 이메일을 입력하면, not_found 응답을 한다.")
     void givenInactiveEmail_whenSendVerifyCode_thenReturnNotFoundStatus() throws Exception {
         mockMvc.perform(delete("/api/members/1"));
         SendVerifyCodeRequest request = new SendVerifyCodeRequest("hong@example.com");

--- a/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
@@ -16,6 +16,7 @@ import org.thisway.auth.dto.request.SendVerifyCodeRequest;
 import org.thisway.common.ApiResponse;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
+import org.thisway.member.support.MemberFixture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -36,19 +37,13 @@ public class AuthControllerTest {
     @BeforeEach
     void setUp() {
         memberRepository.deleteAll();
-        memberRepository.save(Member.builder()
-                .name("홍길동")
-                .email("abc@example.com")
-                .password("password1234")
-                .phone("010-1234-5678")
-                .memo("메모메모")
-                .build());
+        memberRepository.save(MemberFixture.createMember());
     }
 
     @Test
     @DisplayName("이메일 인증 코드 전송에 성공했을 때, ok 응답을 한다.")
     void givenValidEmail_whenSendVerifyCode_thenReturnOkStatus() throws Exception {
-        SendVerifyCodeRequest request = new SendVerifyCodeRequest("abc@example.com");
+        SendVerifyCodeRequest request = new SendVerifyCodeRequest("hong@example.com");
 
         MvcResult mvcResult = mockMvc.perform(
                 post("/api/auth/verify-code")

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -102,7 +102,7 @@ public class EmailVerificationServiceTest {
 
         EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
 
-        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(member));
+        when(memberRepository.findByEmailAndActiveTrue(anyString())).thenReturn(Optional.of(member));
         doNothing().when(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
         doNothing().when(emailVerificationServiceSpy).sendMail(anyString(), anyString());
 

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -1,0 +1,113 @@
+package org.thisway.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.thisway.auth.dto.VerificationPayload;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+import org.thisway.member.entity.Member;
+import org.thisway.member.repository.MemberRepository;
+import org.thisway.member.support.MemberFixture;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+public class EmailVerificationServiceTest {
+
+    @MockitoBean
+    private JavaMailSender javaMailSender;
+    private final StringRedisTemplate redisTemplate;
+
+    private final EmailVerificationService emailVerificationService;
+    @MockitoBean
+    private final MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("생성된 코드가 redis에 저장된다.")
+    void givenValidEmailAndVerifyCode_whenSendVerifyCode_thenStoreCodeInRedis() throws Exception {
+        String email = "abc@example.com";
+        String verifyCode = emailVerificationService.generateVerifyCode();
+        VerificationPayload entry = new VerificationPayload(verifyCode, System.currentTimeMillis()+ 1000*60);
+
+        emailVerificationService.storeCode(email, entry);
+
+        String savedCode = redisTemplate.opsForValue().get(email);
+        assertThat(savedCode).isNotNull();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        VerificationPayload savedEntry = objectMapper.readValue(savedCode, VerificationPayload.class);
+
+        assertThat(savedEntry.code().length()).isEqualTo(6);
+        assertThat(savedEntry.code()).isEqualTo(verifyCode);
+    }
+
+    @Test
+    @DisplayName("메일 발송 과정에서 MailException 에러 발생 시, server_error 응답을 한다.")
+    void whenSendVerifyCodeAndMailExceptionThrown_thenReturnServerErrorStatus() throws Exception {
+        String email = "abc@example.com";
+        String verifyCode = emailVerificationService.generateVerifyCode();
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        doThrow(new MailSendException("메일 전송 실패"))
+                .when(javaMailSender).send(any(MimeMessage.class));
+
+        CustomException e = assertThrows(CustomException.class, () -> emailVerificationService.sendMail(email, verifyCode));
+
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SERVER_ERROR);
+    }
+
+    @Test
+    @DisplayName("메일 발송 과정에서 MessagingException 에러 발생 시, server_error 응답을 한다.")
+    void whenSendVerifyCodeAndMessagingExceptionThrown_thenReturnServerErrorStatus() throws Exception {
+        String email = " ";
+        String verifyCode = emailVerificationService.generateVerifyCode();
+
+        CustomException e = assertThrows(CustomException.class, () -> emailVerificationService.sendMail(email, verifyCode));
+
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.SERVER_ERROR);
+    }
+
+    @Test
+    @DisplayName("sendVerifyCode 실행 시 이메일이 존재하는지 확인하고, storeCode와 sendEmail을 호출한다.")
+    void whenSendVerifyCode_thenCheckEmailExistAndCallStoreCodeAndSendEmail() throws Exception {
+        Member member = MemberFixture.createMember();
+
+        EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
+
+        when(memberRepository.findByEmail(anyString())).thenReturn(Optional.of(member));
+        doNothing().when(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
+        doNothing().when(emailVerificationServiceSpy).sendMail(anyString(), anyString());
+
+        emailVerificationServiceSpy.sendVerifyCode("hong@example.com");
+        verify(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
+        verify(emailVerificationServiceSpy).sendMail(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
    - 이메일 인증 코드 발송 API 생성
- 의존성, 환경 변수, 빌드 관련 코드 업데이트
    - redis, mail 관련 의존성 추가
    - redis, gmail smtp 관련 환경변수 필요

### 📌 관련 이슈
#9 

### ✨ 반영 브랜치
feat/9 -> develop

### 📝 변경 사항
- [x] 비밀번호 변경을 위해 이메일 입력 시 이메일 인증 코드 생성, redis 저장, 이메일 발송

### ➕ 추가 메모
- ToDo
    - 이메일 regex 처리 추가 예정
    - 이메일 ErrorCode 논의 후 변경

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![image](https://github.com/user-attachments/assets/1eda3720-1a07-496a-b87b-f879dc2be3a4)
![image](https://github.com/user-attachments/assets/afaeafed-0c7d-4ec1-968a-d3d170083e11)

