### PR TITLE
비밀번호 변경 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/thisway/auth/controller/AuthController.java
+++ b/src/main/java/org/thisway/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ public class AuthController {
 
     @PostMapping("/verify-code")
     public ApiResponse<Void> sendVerifyCode(@RequestBody SendVerifyCodeRequest request) {
-        emailVerificationService.sendVerifyCode(request.email());
+        emailVerificationService.sendVerifyCode(request);
         return ApiResponse.ok();
     }
 

--- a/src/main/java/org/thisway/auth/controller/AuthController.java
+++ b/src/main/java/org/thisway/auth/controller/AuthController.java
@@ -1,10 +1,8 @@
 package org.thisway.auth.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.thisway.auth.dto.request.PasswordChangeRequest;
 import org.thisway.auth.dto.request.SendVerifyCodeRequest;
 import org.thisway.auth.service.EmailVerificationService;
 import org.thisway.common.ApiResponse;
@@ -19,6 +17,12 @@ public class AuthController {
     @PostMapping("/verify-code")
     public ApiResponse<Void> sendVerifyCode(@RequestBody SendVerifyCodeRequest request) {
         emailVerificationService.sendVerifyCode(request.email());
+        return ApiResponse.ok();
+    }
+
+    @PutMapping("/password")
+    public ApiResponse<Void> changePassword(@RequestBody PasswordChangeRequest request) {
+        emailVerificationService.changePassword(request);
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/org/thisway/auth/controller/AuthController.java
+++ b/src/main/java/org/thisway/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ public class AuthController {
 
     @PostMapping("/verify-code")
     public ApiResponse<Void> sendVerifyCode(@RequestBody SendVerifyCodeRequest request) {
-        emailVerificationService.sendVerifyCode(request);
+        emailVerificationService.sendVerificationCode(request);
         return ApiResponse.ok();
     }
 

--- a/src/main/java/org/thisway/auth/dto/VerificationPayload.java
+++ b/src/main/java/org/thisway/auth/dto/VerificationPayload.java
@@ -5,4 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record VerificationPayload(@NotBlank String code, @NotBlank long expiryTime) {
+
+    public Boolean isExpired() {
+        return System.currentTimeMillis() > expiryTime;
+    }
 }

--- a/src/main/java/org/thisway/auth/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/org/thisway/auth/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,16 @@
+package org.thisway.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordChangeRequest(
+        @NotBlank
+        String email,
+
+        @NotBlank
+        String code,
+
+        @NotBlank
+        String newPassword
+) {
+
+}

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -66,7 +66,7 @@ public class EmailVerificationService {
                     .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
             // todo: 비밀번호 regex 처리
 
-            member.setPassword(request.newPassword());
+            member.updatePassword(request.newPassword());
             memberRepository.save(member);
             redisTemplate.delete(request.email());
         } else {

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -1,6 +1,5 @@
 package org.thisway.auth.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -14,10 +13,13 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thisway.auth.dto.VerificationPayload;
 import org.thisway.auth.dto.request.PasswordChangeRequest;
+import org.thisway.auth.dto.request.SendVerifyCodeRequest;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 import java.security.SecureRandom;
 import java.text.DecimalFormat;
@@ -32,23 +34,26 @@ public class EmailVerificationService {
 
     private final StringRedisTemplate redisTemplate;
     private final JavaMailSender javaMailSender;
+    private final ObjectMapper objectMapper;
+
+    private final TemplateEngine templateEngine;
 
     @Value("${custom.auth-code-expiration-millis}")
     private long authCodeExpirationMills;
 
-    public void sendVerifyCode(String email) {
+    public void sendVerifyCode(SendVerifyCodeRequest request) {
         // todo: 이메일 regex 처리 예정.
 
         // todo: ErrorCode 논의 후 변경 예정.
-        memberRepository.findByEmailAndActiveTrue(email)
+        memberRepository.findByEmailAndActiveTrue(request.email())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         String code = generateVerifyCode();
 
         VerificationPayload verificationPayload = new VerificationPayload(code, System.currentTimeMillis() + authCodeExpirationMills);
-        storeCode(email, verificationPayload);
+        storeCode(request.email(), verificationPayload);
 
-        sendMail(email, code);
+        sendMail(request.email(), code);
     }
 
     public void changePassword(PasswordChangeRequest request) {
@@ -75,7 +80,6 @@ public class EmailVerificationService {
 
     public void storeCode(String email, VerificationPayload verificationPayload) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
             String json = objectMapper.writeValueAsString(verificationPayload);
             redisTemplate.opsForValue().set(email, json, authCodeExpirationMills, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
@@ -99,7 +103,6 @@ public class EmailVerificationService {
             String savedCode = redisTemplate.opsForValue().get(email);
 
             if (savedCode != null && !savedCode.isBlank()) {
-                ObjectMapper objectMapper = new ObjectMapper();
                 return objectMapper.readValue(savedCode, VerificationPayload.class);
             } else return null;
         } catch (Exception e) {
@@ -123,140 +126,8 @@ public class EmailVerificationService {
     }
 
     public String generateEmailContent(String code) {
-        String html = String.format("""
-                <!DOCTYPE html>
-                <html lang="ko">
-                <head>
-                    <meta charset="UTF-8">
-                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                    <title>이메일 인증 코드</title>
-                    <style>
-                        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto+Mono:wght@700&display=swap');
-                
-                        body {
-                            font-family: 'Inter', sans-serif;
-                            margin: 0;
-                            padding: 0;
-                            background-color: #F9FAFB;
-                            color: #111827;
-                        }
-                
-                        .container {
-                            max-width: 600px;
-                            margin: 0 auto;
-                            background-color: #FFFFFF;
-                            padding: 40px;
-                        }
-                
-                        .header {
-                            text-align: center;
-                            margin-bottom: 32px;
-                            display: flex;
-                            align-items: center;
-                            justify-content: center;
-                            gap: 12px;
-                        }
-                
-                        .logo {
-                            width: 40px;
-                            height: 40px;
-                        }
-                
-                        .service-name {
-                            font-size: 24px;
-                            font-weight: 700;
-                            margin: 0;
-                        }
-                
-                        .content {
-                            margin-bottom: 32px;
-                        }
-                
-                        .title {
-                            font-size: 20px;
-                            font-weight: 700;
-                            text-align: center;
-                            margin-bottom: 8px;
-                        }
-                
-                        .subtitle {
-                            font-size: 16px;
-                            color: #4B5563;
-                            text-align: center;
-                            margin-bottom: 24px;
-                        }
-                
-                        .code-container {
-                            background-color: #F3F4F6;
-                            border-radius: 8px;
-                            padding: 24px;
-                            text-align: center;
-                            margin-bottom: 16px;
-                        }
-                
-                        .code {
-                            font-family: 'Roboto Mono', monospace;
-                            font-size: 32px;
-                            font-weight: 700;
-                            letter-spacing: 4px;
-                        }
-                
-                        .expiry {
-                            font-size: 14px;
-                            color: #6B7280;
-                            text-align: center;
-                            margin-bottom: 24px;
-                        }
-                
-                        .divider {
-                            height: 1px;
-                            background-color: #E5E7EB;
-                            margin: 24px 0 16px 0;
-                        }
-                
-                        .footer {
-                            color: #9CA3AF;
-                            font-size: 14px;
-                            text-align: center;
-                        }
-                
-                        .footer p {
-                            margin: 4px 0;
-                        }
-                    </style>
-                </head>
-                <body>
-                    <div class="container">
-                        <div class="header">
-                            <svg class="logo" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <rect width="40" height="40" rx="8" fill="#4F46E5"/>
-                                <path d="M20 10L28 18L20 26L12 18L20 10Z" fill="white"/>
-                            </svg>
-                            <h1 class="service-name">ThisWay</h1>
-                        </div>
-                
-                        <div class="content">
-                            <h2 class="title">이메일 인증 코드</h2>
-                            <p class="subtitle">아래 인증 코드를 입력하여 이메일 인증을 완료해 주세요.</p>
-                
-                            <div class="code-container">
-                                <div class="code">%s</div>
-                            </div>
-                            <p class="expiry">인증 코드는 10분 동안 유효합니다.</p>
-                
-                        </div>
-                
-                        <div class="divider"></div>
-                
-                        <div class="footer">
-                            <p>본 이메일은 발신 전용이며, 회신하실 수 없습니다.</p>
-                            <p>© 2025 Thisway. All rights reserved.</p>
-                        </div>
-                    </div>
-                </body>
-                </html>
-                """, code);
-
-        return html;
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("email-content", context);
     }
 }

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -42,14 +42,14 @@ public class EmailVerificationService {
     private long authCodeExpirationMills;
 
     @Transactional(readOnly = true)
-    public void sendVerifyCode(SendVerifyCodeRequest request) {
+    public void sendVerificationCode(SendVerifyCodeRequest request) {
         // todo: 이메일 regex 처리 예정.
 
         // todo: ErrorCode 논의 후 변경 예정.
         memberRepository.findByEmailAndActiveTrue(request.email())
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        String code = generateVerifyCode();
+        String code = generateVerificationCode();
 
         VerificationPayload verificationPayload = new VerificationPayload(code, System.currentTimeMillis() + authCodeExpirationMills);
         storeCode(request.email(), verificationPayload);
@@ -74,7 +74,7 @@ public class EmailVerificationService {
         }
     }
 
-    public String generateVerifyCode() {
+    public String generateVerificationCode() {
         DecimalFormat CODE_FORMAT = new DecimalFormat("000000");
         SecureRandom secureRandom = new SecureRandom();
         return CODE_FORMAT.format(secureRandom.nextInt(900000) + 100000);

--- a/src/main/java/org/thisway/auth/service/EmailVerificationService.java
+++ b/src/main/java/org/thisway/auth/service/EmailVerificationService.java
@@ -11,6 +11,7 @@ import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.thisway.auth.dto.VerificationPayload;
 import org.thisway.auth.dto.request.PasswordChangeRequest;
 import org.thisway.auth.dto.request.SendVerifyCodeRequest;
@@ -27,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class EmailVerificationService {
 
     private final MemberRepository memberRepository;
@@ -41,6 +41,7 @@ public class EmailVerificationService {
     @Value("${custom.auth-code-expiration-millis}")
     private long authCodeExpirationMills;
 
+    @Transactional(readOnly = true)
     public void sendVerifyCode(SendVerifyCodeRequest request) {
         // todo: 이메일 regex 처리 예정.
 
@@ -56,6 +57,7 @@ public class EmailVerificationService {
         sendMail(request.email(), code);
     }
 
+    @Transactional
     public void changePassword(PasswordChangeRequest request) {
         // todo: 이메일 regex 처리
 

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -51,7 +51,7 @@ public class Member extends BaseEntity {
         return phone.getValue();
     }
 
-    public void setPassword(String password) {
+    public void updatePassword(String password) {
         this.password = password;
     }
 }

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -50,4 +50,8 @@ public class Member extends BaseEntity {
     public String getPhoneValue() {
         return phone.getValue();
     }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/resources/templates/email-content.html
+++ b/src/main/resources/templates/email-content.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>이메일 인증 코드</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Roboto+Mono:wght@700&display=swap');
+
+        body {
+            font-family: 'Inter', sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #F9FAFB;
+            color: #111827;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #FFFFFF;
+            padding: 40px;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 32px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+
+        .logo {
+            width: 40px;
+            height: 40px;
+        }
+
+        .service-name {
+            font-size: 24px;
+            font-weight: 700;
+            margin: 0;
+        }
+
+        .content {
+            margin-bottom: 32px;
+        }
+
+        .title {
+            font-size: 20px;
+            font-weight: 700;
+            text-align: center;
+            margin-bottom: 8px;
+        }
+
+        .subtitle {
+            font-size: 16px;
+            color: #4B5563;
+            text-align: center;
+            margin-bottom: 24px;
+        }
+
+        .code-container {
+            background-color: #F3F4F6;
+            border-radius: 8px;
+            padding: 24px;
+            text-align: center;
+            margin-bottom: 16px;
+        }
+
+        .code {
+            font-family: 'Roboto Mono', monospace;
+            font-size: 32px;
+            font-weight: 700;
+            letter-spacing: 4px;
+        }
+
+        .expiry {
+            font-size: 14px;
+            color: #6B7280;
+            text-align: center;
+            margin-bottom: 24px;
+        }
+
+        .divider {
+            height: 1px;
+            background-color: #E5E7EB;
+            margin: 24px 0 16px 0;
+        }
+
+        .footer {
+            color: #9CA3AF;
+            font-size: 14px;
+            text-align: center;
+        }
+
+        .footer p {
+            margin: 4px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <svg class="logo" width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect width="40" height="40" rx="8" fill="#4F46E5"/>
+                <path d="M20 10L28 18L20 26L12 18L20 10Z" fill="white"/>
+            </svg>
+            <h1 class="service-name">ThisWay</h1>
+        </div>
+
+        <div class="content">
+            <h2 class="title">이메일 인증 코드</h2>
+            <p class="subtitle">아래 인증 코드를 입력하여 이메일 인증을 완료해 주세요.</p>
+
+            <div class="code-container">
+                <div class="code" th:text="${code}"></div>
+            </div>
+            <p class="expiry">인증 코드는 10분 동안 유효합니다.</p>
+
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="footer">
+            <p>본 이메일은 발신 전용이며, 회신하실 수 없습니다.</p>
+            <p>© 2025 Thisway. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -49,7 +49,7 @@ public class EmailVerificationServiceTest {
     @DisplayName("생성된 코드가 redis에 저장된다.")
     void givenValidEmailAndVerifyCode_whenSendVerifyCode_thenStoreCodeInRedis() throws Exception {
         String email = "abc@example.com";
-        String verifyCode = emailVerificationService.generateVerifyCode();
+        String verifyCode = emailVerificationService.generateVerificationCode();
         VerificationPayload entry = new VerificationPayload(verifyCode, System.currentTimeMillis()+ 1000*60);
 
         emailVerificationService.storeCode(email, entry);
@@ -67,7 +67,7 @@ public class EmailVerificationServiceTest {
     @DisplayName("메일 발송 과정에서 MailException 에러 발생 시, server_error 응답을 한다.")
     void whenSendVerifyCodeAndMailExceptionThrown_thenReturnServerErrorStatus() throws Exception {
         String email = "abc@example.com";
-        String verifyCode = emailVerificationService.generateVerifyCode();
+        String verifyCode = emailVerificationService.generateVerificationCode();
 
         MimeMessage mimeMessage = mock(MimeMessage.class);
         when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
@@ -84,7 +84,7 @@ public class EmailVerificationServiceTest {
     @DisplayName("메일 발송 과정에서 MessagingException 에러 발생 시, server_error 응답을 한다.")
     void whenSendVerifyCodeAndMessagingExceptionThrown_thenReturnServerErrorStatus() throws Exception {
         String email = " ";
-        String verifyCode = emailVerificationService.generateVerifyCode();
+        String verifyCode = emailVerificationService.generateVerificationCode();
 
         CustomException e = assertThrows(CustomException.class, () -> emailVerificationService.sendMail(email, verifyCode));
 
@@ -103,7 +103,7 @@ public class EmailVerificationServiceTest {
         doNothing().when(emailVerificationServiceSpy).sendMail(anyString(), anyString());
 
         SendVerifyCodeRequest request = new SendVerifyCodeRequest(member.getEmail());
-        emailVerificationServiceSpy.sendVerifyCode(request);
+        emailVerificationServiceSpy.sendVerificationCode(request);
         verify(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
         verify(emailVerificationServiceSpy).sendMail(anyString(), anyString());
     }

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -3,7 +3,6 @@ package org.thisway.auth.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -15,6 +14,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.thisway.auth.dto.VerificationPayload;
+import org.thisway.auth.dto.request.PasswordChangeRequest;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.entity.Member;
@@ -42,11 +42,6 @@ public class EmailVerificationServiceTest {
     private final EmailVerificationService emailVerificationService;
     @MockitoBean
     private final MemberRepository memberRepository;
-
-    @BeforeEach
-    void setUp() {
-        memberRepository.deleteAll();
-    }
 
     @Test
     @DisplayName("생성된 코드가 redis에 저장된다.")
@@ -110,4 +105,63 @@ public class EmailVerificationServiceTest {
         verify(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
         verify(emailVerificationServiceSpy).sendMail(anyString(), anyString());
     }
+
+    @Test
+    @DisplayName("verifyCode 실행 시 retrieveFromRedis를 호출한다.")
+    void whenVerifyCode_thenCallRetrieveFromRedis() throws Exception {
+        EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
+
+        VerificationPayload entry = new VerificationPayload("123456", System.currentTimeMillis() + 60000);
+        doReturn(entry).when(emailVerificationServiceSpy).retrieveFromRedis(anyString());
+        emailVerificationServiceSpy.verifyCode("hong@example.com", "123456");
+        verify(emailVerificationServiceSpy).retrieveFromRedis(anyString());
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 시 유효한 코드라면 True 반환")
+    void givenValidCode_whenVerifyCode_thenReturnTrue() throws Exception {
+        EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
+
+        VerificationPayload entry = new VerificationPayload("123456", System.currentTimeMillis() + 60000);
+        doReturn(entry).when(emailVerificationServiceSpy).retrieveFromRedis(any(String.class));
+
+        assertThat(emailVerificationServiceSpy.verifyCode("hong@example.com", "123456").booleanValue()).isTrue();
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 시 잘못된 코드라면 False 반환")
+    void givenWrongCode_whenVerifyCode_thenReturnFalse() throws Exception {
+        EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
+
+        VerificationPayload entry = new VerificationPayload("123456", System.currentTimeMillis() + 60000);
+        doReturn(entry).when(emailVerificationServiceSpy).retrieveFromRedis(any(String.class));
+
+        assertThat(emailVerificationServiceSpy.verifyCode("hong@example.com", "654321").booleanValue()).isFalse();
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증 시 만료된 코드라면 False 반환")
+    void givenExpiredCode_whenVerifyCode_thenReturnFalse() throws Exception {
+        EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
+
+        VerificationPayload entry = new VerificationPayload("123456", System.currentTimeMillis() - 10000);
+        doReturn(entry).when(emailVerificationServiceSpy).retrieveFromRedis(any(String.class));
+
+        assertThat(emailVerificationServiceSpy.verifyCode("hong@example.com", "123456").booleanValue()).isFalse();
+    }
+
+    @Test
+    @DisplayName("changePassword 실행 시 verifyCode를 호출한다.")
+    void whenChangePassword_then() throws Exception {
+        Member member = MemberFixture.createMember();
+        EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
+
+        doReturn(Optional.of(member)).when(memberRepository).findByEmailAndActiveTrue(anyString());
+        doReturn(true).when(emailVerificationServiceSpy).verifyCode(anyString(), anyString());
+
+        PasswordChangeRequest request = new PasswordChangeRequest(member.getEmail(), "123456", "theNewPassword");
+        emailVerificationServiceSpy.changePassword(request);
+        verify(emailVerificationServiceSpy).verifyCode(member.getEmail(), "123456");
+    }
+
 }

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.thisway.auth.dto.VerificationPayload;
 import org.thisway.auth.dto.request.PasswordChangeRequest;
+import org.thisway.auth.dto.request.SendVerifyCodeRequest;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.entity.Member;
@@ -38,6 +39,7 @@ public class EmailVerificationServiceTest {
     @MockitoBean
     private JavaMailSender javaMailSender;
     private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
 
     private final EmailVerificationService emailVerificationService;
     @MockitoBean
@@ -55,7 +57,6 @@ public class EmailVerificationServiceTest {
         String savedCode = redisTemplate.opsForValue().get(email);
         assertThat(savedCode).isNotNull();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         VerificationPayload savedEntry = objectMapper.readValue(savedCode, VerificationPayload.class);
 
         assertThat(savedEntry.code().length()).isEqualTo(6);
@@ -101,7 +102,8 @@ public class EmailVerificationServiceTest {
         doNothing().when(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
         doNothing().when(emailVerificationServiceSpy).sendMail(anyString(), anyString());
 
-        emailVerificationServiceSpy.sendVerifyCode("hong@example.com");
+        SendVerifyCodeRequest request = new SendVerifyCodeRequest(member.getEmail());
+        emailVerificationServiceSpy.sendVerifyCode(request);
         verify(emailVerificationServiceSpy).storeCode(anyString(), any(VerificationPayload.class));
         verify(emailVerificationServiceSpy).sendMail(anyString(), anyString());
     }

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -152,7 +152,7 @@ public class EmailVerificationServiceTest {
 
     @Test
     @DisplayName("changePassword 실행 시 verifyCode를 호출한다.")
-    void whenChangePassword_then() throws Exception {
+    void whenChangePassword_thenCallVerifyCode() throws Exception {
         Member member = MemberFixture.createMember();
         EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
 


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 버그 수정
- 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📌 관련 이슈
#32 #9

### ✨ 반영 브랜치
feat/32 -> develop

### 📝 변경 사항
- [x] 비밀번호 변경 API 추가
- [x] authControllerTest에서 실DB에 값 변경되는 버그 수정
- [x] 그 외 리팩토링
    - [x] ObjectMapper 클래스 필드로 변경
    - [x] 이메일 html 포맷 별도의 파일로 생성
    - [x] sendVerifyCode 메서드 파라미터 수정

### ➕ 추가 메모
- ToDo
    - 이메일 regex 처리
    - ErrorCode 추후 리팩토리 예정
    - 비밀번호 regex 처리

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![image](https://github.com/user-attachments/assets/f846fcb4-1654-4237-98d4-103ebe4190e6)

