### PR TITLE
MemberFixture 시그니처 변경 반영하여 테스트 수정

### DIFF
--- a/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/thisway/auth/controller/AuthControllerTest.java
@@ -1,8 +1,12 @@
 package org.thisway.auth.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,17 +19,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.thisway.auth.dto.request.SendVerifyCodeRequest;
 import org.thisway.common.ApiResponse;
+import org.thisway.company.entity.Company;
+import org.thisway.company.repository.CompanyRepository;
+import org.thisway.company.support.CompanyFixture;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
 import org.thisway.member.support.MemberFixture;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,11 +36,14 @@ public class AuthControllerTest {
     private final ObjectMapper objectMapper;
 
     private final MemberRepository memberRepository;
+    private final CompanyRepository companyRepository;
 
     @BeforeEach
     void setUp() {
         memberRepository.deleteAll();
-        memberRepository.save(MemberFixture.createMember());
+        companyRepository.deleteAll();
+        Company company = companyRepository.save(CompanyFixture.createCompany());
+        memberRepository.save(MemberFixture.createMember(company));
     }
 
     @Test

--- a/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/org/thisway/auth/service/EmailVerificationServiceTest.java
@@ -1,7 +1,18 @@
 package org.thisway.auth.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.mail.internet.MimeMessage;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,17 +28,11 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.thisway.auth.dto.VerificationPayload;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
+import org.thisway.company.entity.Company;
+import org.thisway.company.support.CompanyFixture;
 import org.thisway.member.entity.Member;
 import org.thisway.member.repository.MemberRepository;
 import org.thisway.member.support.MemberFixture;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -98,7 +103,8 @@ public class EmailVerificationServiceTest {
     @Test
     @DisplayName("sendVerifyCode 실행 시 이메일이 존재하는지 확인하고, storeCode와 sendEmail을 호출한다.")
     void whenSendVerifyCode_thenCheckEmailExistAndCallStoreCodeAndSendEmail() throws Exception {
-        Member member = MemberFixture.createMember();
+        Company company = CompanyFixture.createCompany();
+        Member member = MemberFixture.createMember(company);
 
         EmailVerificationService emailVerificationServiceSpy = Mockito.spy(emailVerificationService);
 


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 버그 수정

### 📌 관련 이슈
- #50 

### ✨ 반영 브랜치
ex) feat/50 -> develop

### 📝 변경 사항
#### 변경 배경
- MemberFixture.createMember() 메서드의 시그니처가 createMember(Company company)로 변경되었으나, develop 브랜치에 기존 시그니처 (createMember())를 사용하는 테스트 코드가 병합되어 테스트 실행 시 실패가 발생

#### 변경 사항
- 관련 테스트 코드 및 호출부 수정

### ➕ 추가 메모

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![Test 성공 스크린샷](https://github.com/user-attachments/assets/7be8f65f-4518-4a35-a43a-f4140b1cd2e9)
