### PR TITLE
Spring Security를 사용한 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation("io.jsonwebtoken:jjwt:0.12.6")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'
@@ -39,8 +43,11 @@ dependencies {
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/org/thisway/member/controller/MemberController.java
+++ b/src/main/java/org/thisway/member/controller/MemberController.java
@@ -35,7 +35,6 @@ public class MemberController {
         return ApiResponse.ok(memberService.getMembers(pageable));
     }
 
-
     @PostMapping
     public ApiResponse<Void> registerMember(@RequestBody @Validated MemberRegisterRequest request) {
         memberService.registerMember(request);

--- a/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
@@ -19,17 +19,6 @@ public record MemberRegisterRequest(
 
         @NotNull String memo) {
 
-    public Member toMember(Company company) {
-        return Member.builder()
-                .company(company)
-                .name(name)
-                .email(email)
-                .password(password)
-                .phone(phone)
-                .memo(memo)
-                .build();
-    }
-
     public Member toMember(Company company, String encodedPassword) {
         return Member.builder()
                 .company(company)

--- a/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
@@ -7,24 +7,17 @@ import org.thisway.member.entity.Member;
 
 public record MemberRegisterRequest(
 
-        @NotNull
-        Long companyId,
+        @NotNull Long companyId,
 
-        @NotBlank
-        String name,
+        @NotBlank String name,
 
-        @NotBlank
-        String email,
+        @NotBlank String email,
 
-        @NotBlank
-        String password,
+        @NotBlank String password,
 
-        @NotBlank
-        String phone,
+        @NotBlank String phone,
 
-        @NotNull
-        String memo
-) {
+        @NotNull String memo) {
 
     public Member toMember(Company company) {
         return Member.builder()
@@ -32,6 +25,17 @@ public record MemberRegisterRequest(
                 .name(name)
                 .email(email)
                 .password(password)
+                .phone(phone)
+                .memo(memo)
+                .build();
+    }
+
+    public Member toMember(Company company, String encodedPassword) {
+        return Member.builder()
+                .company(company)
+                .name(name)
+                .email(email)
+                .password(encodedPassword)
                 .phone(phone)
                 .memo(memo)
                 .build();

--- a/src/main/java/org/thisway/member/service/MemberService.java
+++ b/src/main/java/org/thisway/member/service/MemberService.java
@@ -2,6 +2,7 @@ package org.thisway.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thisway.common.BaseEntity;
@@ -22,6 +23,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final CompanyRepository companyRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public MemberResponse getMemberDetail(Long id) {
@@ -45,7 +47,9 @@ public class MemberService {
                 .filter(BaseEntity::isActive)
                 .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
 
-        Member member = request.toMember(company);
+        String encryptedPassword = passwordEncoder.encode(request.password());
+
+        Member member = request.toMember(company, encryptedPassword);
 
         memberRepository.save(member);
     }

--- a/src/main/java/org/thisway/security/config/AuthenticationConfig.java
+++ b/src/main/java/org/thisway/security/config/AuthenticationConfig.java
@@ -1,0 +1,50 @@
+package org.thisway.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.thisway.security.service.CustomUserDetailsService;
+
+@Configuration
+public class AuthenticationConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * 이 메서드는 현재 어떻게 작동되는지 이해하지 못하고 넣어둠...
+     */
+    @Bean
+    AuthenticationEntryPoint restAuthEntryPoint() {
+        return (request, response, authException) -> {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), authException.getMessage());
+        };
+    }
+
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider(
+            CustomUserDetailsService userDetailsService,
+            PasswordEncoder passwordEncoder
+
+    ) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration
+
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/org/thisway/security/config/FilterConfig.java
+++ b/src/main/java/org/thisway/security/config/FilterConfig.java
@@ -1,0 +1,49 @@
+package org.thisway.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+
+import org.thisway.security.handler.JsonAuthenticationFailureHandler;
+import org.thisway.security.handler.JsonAuthenticationSuccessHandler;
+import org.thisway.security.utils.JwtTokenUtil;
+import org.thisway.security.filter.GlobalExceptionHandlerFilter;
+import org.thisway.security.filter.JsonAuthenticationFilter;
+import org.thisway.security.filter.JwtAuthenticationFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public GlobalExceptionHandlerFilter globalExceptionHandlerFilter(
+            ObjectMapper objectMapper
+
+    ) {
+        return new GlobalExceptionHandlerFilter(objectMapper);
+    }
+
+    @Bean
+    public JsonAuthenticationFilter jsonAuthenticationFilter(
+            AuthenticationManager authManager,
+            JwtTokenUtil jwtTokenUtil
+
+    ) {
+        JsonAuthenticationFilter filter = new JsonAuthenticationFilter(authManager);
+
+        filter.setAuthenticationSuccessHandler(
+                new JsonAuthenticationSuccessHandler(jwtTokenUtil));
+        filter.setAuthenticationFailureHandler(
+                new JsonAuthenticationFailureHandler());
+        return filter;
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(
+            JwtTokenUtil jwtTokenUtil
+
+    ) {
+        return new JwtAuthenticationFilter(jwtTokenUtil);
+    }
+}

--- a/src/main/java/org/thisway/security/config/SecurityConfig.java
+++ b/src/main/java/org/thisway/security/config/SecurityConfig.java
@@ -3,29 +3,18 @@ package org.thisway.security.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.context.SecurityContextHolderFilter;
+
 import org.thisway.security.filter.GlobalExceptionHandlerFilter;
 import org.thisway.security.filter.JsonAuthenticationFilter;
 import org.thisway.security.filter.JwtAuthenticationFilter;
-import org.thisway.security.handler.JsonAuthenticationFailureHandler;
-import org.thisway.security.handler.JsonAuthenticationSuccessHandler;
-import org.thisway.security.service.CustomUserDetailsService;
-import org.thisway.security.utils.JwtTokenUtil;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,74 +22,14 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final JwtTokenUtil jwtTokenUtil;
-    private final AuthenticationConfiguration authenticationConfiguration;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    /**
-     * 이 메서드는 현재 어떻게 작동되는지 이해하지 못하고 넣어둠...
-     */
-    @Bean
-    AuthenticationEntryPoint restAuthEntryPoint() {
-        return (request, response, authException) -> {
-            response.sendError(HttpStatus.UNAUTHORIZED.value(), authException.getMessage());
-        };
-    }
-
-    @Bean
-    public GlobalExceptionHandlerFilter globalExceptionHandlerFilter(
-            ObjectMapper objectMapper) {
-        return new GlobalExceptionHandlerFilter(objectMapper);
-    }
-
-    @Bean
-    public DaoAuthenticationProvider daoAuthenticationProvider(
-            CustomUserDetailsService userDetailsService,
-            PasswordEncoder passwordEncoder) {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(userDetailsService);
-        provider.setPasswordEncoder(passwordEncoder);
-        return provider;
-    }
-
-    @Bean
-    public JsonAuthenticationFilter jsonAuthenticationFilter(
-            AuthenticationManager authManager
-
-    ) {
-        JsonAuthenticationFilter filter = new JsonAuthenticationFilter(authManager);
-
-        filter.setAuthenticationSuccessHandler(
-                new JsonAuthenticationSuccessHandler(jwtTokenUtil));
-        filter.setAuthenticationFailureHandler(
-                new JsonAuthenticationFailureHandler());
-        return filter;
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(
-            AuthenticationConfiguration authenticationConfiguration
-
-    ) throws Exception {
-        return authenticationConfiguration.getAuthenticationManager();
-    }
-
-    @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtTokenUtil);
-    }
-
     @Bean
     public SecurityFilterChain filterChain(
             HttpSecurity http,
             GlobalExceptionHandlerFilter globalExceptionHandlerFilter,
             JsonAuthenticationFilter jsonAuthenticationFilter,
-            JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+            JwtAuthenticationFilter jwtAuthenticationFilter
 
+    ) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -116,6 +45,7 @@ public class SecurityConfig {
                 .addFilterAfter(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
                 // TODO: 공통 에러 응답 형태로 리팩토링 필요
+                // 이 부분은 현재 적용 안되고 있을 확률이 높습니다. 추가 테스트 후 리팩토링 할 예정
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                         .accessDeniedHandler(

--- a/src/main/java/org/thisway/security/config/SecurityConfig.java
+++ b/src/main/java/org/thisway/security/config/SecurityConfig.java
@@ -1,0 +1,134 @@
+package org.thisway.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.thisway.security.filter.GlobalExceptionHandlerFilter;
+import org.thisway.security.filter.JsonAuthenticationFilter;
+import org.thisway.security.filter.JwtAuthenticationFilter;
+import org.thisway.security.handler.JsonAuthenticationFailureHandler;
+import org.thisway.security.handler.JsonAuthenticationSuccessHandler;
+import org.thisway.security.service.CustomUserDetailsService;
+import org.thisway.security.utils.JwtTokenUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenUtil jwtTokenUtil;
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * 이 메서드는 현재 어떻게 작동되는지 이해하지 못하고 넣어둠...
+     */
+    @Bean
+    AuthenticationEntryPoint restAuthEntryPoint() {
+        return (request, response, authException) -> {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), authException.getMessage());
+        };
+    }
+
+    @Bean
+    public GlobalExceptionHandlerFilter globalExceptionHandlerFilter(
+            ObjectMapper objectMapper) {
+        return new GlobalExceptionHandlerFilter(objectMapper);
+    }
+
+    @Bean
+    public DaoAuthenticationProvider daoAuthenticationProvider(
+            CustomUserDetailsService userDetailsService,
+            PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
+    }
+
+    @Bean
+    public JsonAuthenticationFilter jsonAuthenticationFilter(
+            AuthenticationManager authManager
+
+    ) {
+        JsonAuthenticationFilter filter = new JsonAuthenticationFilter(authManager);
+
+        filter.setAuthenticationSuccessHandler(
+                new JsonAuthenticationSuccessHandler(jwtTokenUtil));
+        filter.setAuthenticationFailureHandler(
+                new JsonAuthenticationFailureHandler());
+        return filter;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration
+
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenUtil);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            GlobalExceptionHandlerFilter globalExceptionHandlerFilter,
+            JsonAuthenticationFilter jsonAuthenticationFilter,
+            JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(
+                                SessionCreationPolicy.STATELESS))
+
+                .addFilterBefore(globalExceptionHandlerFilter,
+                        SecurityContextHolderFilter.class)
+                .addFilterAt(jsonAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class)
+                // TODO: 공통 에러 응답 형태로 리팩토링 필요
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler(
+                                (
+                                        req,
+                                        res,
+                                        accessEx) -> res.sendError(
+                                                HttpStatus.FORBIDDEN.value(),
+                                                "Forbidden")))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .build();
+    }
+
+}

--- a/src/main/java/org/thisway/security/dto/request/LoginRequest.java
+++ b/src/main/java/org/thisway/security/dto/request/LoginRequest.java
@@ -1,0 +1,9 @@
+package org.thisway.security.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String email,
+
+        @NotBlank String password) {
+}

--- a/src/main/java/org/thisway/security/filter/GlobalExceptionHandlerFilter.java
+++ b/src/main/java/org/thisway/security/filter/GlobalExceptionHandlerFilter.java
@@ -1,0 +1,83 @@
+package org.thisway.security.filter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class GlobalExceptionHandlerFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    // TODO: Custom Filter에서 발생한 예외 처리 하는 부분인데 아직 미완성.
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException ex) {
+            log.error("JWT authentication error", ex);
+            sendError(
+                    response,
+                    HttpStatus.UNAUTHORIZED,
+                    "UNAUTHORIZED",
+                    ex.getMessage());
+
+        } catch (AuthenticationServiceException ex) {
+            log.error("Authentication service error", ex);
+            sendError(
+                    response,
+                    HttpStatus.BAD_REQUEST,
+                    "BAD_REQUEST",
+                    ex.getMessage());
+
+        } catch (BadCredentialsException ex) {
+            log.error("Bad credentials error", ex);
+            sendError(
+                    response,
+                    HttpStatus.UNAUTHORIZED,
+                    "UNAUTHORIZED",
+                    ex.getMessage());
+
+        } catch (Exception ex) {
+            log.error("Unhandled exception occurred", ex);
+            sendError(
+                    response,
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "INTERNAL_SERVER_ERROR",
+                    ex.getMessage());
+
+        }
+    }
+
+    // TODO:: 이 부분은 공통 응답과 맞출 수 있게 수정해야 함
+    private void sendError(HttpServletResponse response,
+            HttpStatus status,
+            String code,
+            String message)
+            throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(
+                response.getWriter(),
+                Map.of("code", code, "message", message));
+    }
+
+}

--- a/src/main/java/org/thisway/security/filter/JsonAuthenticationFilter.java
+++ b/src/main/java/org/thisway/security/filter/JsonAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package org.thisway.security.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.thisway.security.dto.request.LoginRequest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JsonAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = new AntPathRequestMatcher(
+            "/api/auth/login", "POST");
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JsonAuthenticationFilter(
+            AuthenticationManager authManager) {
+        super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+        setAuthenticationManager(authManager);
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response) throws AuthenticationException, IOException {
+
+        // startsWith("application/json")
+        if (!request.getContentType().equalsIgnoreCase(MediaType.APPLICATION_JSON_VALUE)) {
+            throw new AuthenticationServiceException("Unsupported content type: " + request.getContentType());
+        }
+
+        LoginRequest loginRequest = objectMapper.readValue(
+                request.getInputStream(),
+                LoginRequest.class);
+
+        UsernamePasswordAuthenticationToken authRequest = UsernamePasswordAuthenticationToken.unauthenticated(
+                loginRequest.email(),
+                loginRequest.password());
+
+        return getAuthenticationManager().authenticate(authRequest);
+    }
+}

--- a/src/main/java/org/thisway/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/thisway/security/filter/JwtAuthenticationFilter.java
@@ -65,7 +65,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (header != null && header.startsWith("Bearer ")) {
-            return header.substring(7);
+            return header.substring("Bearer ".length());
         }
         return null;
     }
@@ -75,6 +75,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         // 로그인이나 회원가입 같이 JWT 검증이 필요 없는 요청은 필터를 건너뛴다.
         String path = request.getServletPath();
-        return "/api/auth/login".equals(path) || "/api/auth/register".equals(path);
+        return "/api/auth/login".equals(path);
     }
 }

--- a/src/main/java/org/thisway/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/thisway/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,80 @@
+package org.thisway.security.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.thisway.security.utils.JwtTokenUtil;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenUtil jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 서명, 만료 검증 & Claims 파싱
+        Claims claims = jwtTokenProvider.validateTokenAndGetClaims(token);
+
+        // sub(Claims) 존재 여부 검사
+        String username = claims.getSubject();
+
+        if (username == null || username.isBlank())
+            throw new BadCredentialsException("Invalid JWT token: missing subject");
+
+        @SuppressWarnings("unchecked")
+        List<String> roles = claims.get("roles", List.class);
+        // List<String> roles = (List<String>) claims.get("roles");
+        if (roles == null)
+            roles = List.of();
+        String[] authorities = roles.toArray(String[]::new);
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                username,
+                null,
+                AuthorityUtils.createAuthorityList(authorities));
+
+        SecurityContextHolder
+                .getContext()
+                .setAuthentication(auth);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+
+    // 이렇게 사용할지 아직 미정
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 로그인이나 회원가입 같이 JWT 검증이 필요 없는 요청은 필터를 건너뛴다.
+        String path = request.getServletPath();
+        return "/api/auth/login".equals(path) || "/api/auth/register".equals(path);
+    }
+}

--- a/src/main/java/org/thisway/security/handler/JsonAuthenticationFailureHandler.java
+++ b/src/main/java/org/thisway/security/handler/JsonAuthenticationFailureHandler.java
@@ -1,0 +1,23 @@
+package org.thisway.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JsonAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write("{\"error\":\"" + exception.getMessage() + "\"}");
+    }
+}

--- a/src/main/java/org/thisway/security/handler/JsonAuthenticationSuccessHandler.java
+++ b/src/main/java/org/thisway/security/handler/JsonAuthenticationSuccessHandler.java
@@ -1,0 +1,51 @@
+package org.thisway.security.handler;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.thisway.security.utils.JwtTokenUtil;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JsonAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenUtil jwtTokenUtil;
+
+    public JsonAuthenticationSuccessHandler(JwtTokenUtil jwtTokenUtil) {
+        this.jwtTokenUtil = jwtTokenUtil;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) throws IOException, ServletException {
+        // Handle successful authentication
+        String subject = authentication.getName();
+        Map<String, Object> claims = new HashMap<>();
+
+        authentication
+                .getAuthorities()
+                .forEach(auth -> claims.put(
+                        auth.getAuthority(),
+                        true));
+
+        // log.info("Authentication successful for user: {} {}", subject,
+        // authentication.getAuthorities());
+        log.info("creating JWT for user: {} with claims: {}", subject, claims);
+
+        String jwt = jwtTokenUtil.createAccessToken(subject, claims);
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwt);
+    }
+
+}

--- a/src/main/java/org/thisway/security/provider/JwtTokenProvider.java
+++ b/src/main/java/org/thisway/security/provider/JwtTokenProvider.java
@@ -1,0 +1,47 @@
+package org.thisway.security.provider;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtTokenProvider {
+    // TODO : DTO 변경 생각하기.
+    private final SecretKey secretKey;
+    private final Long accessTokenValidityMs;
+
+    public JwtTokenProvider(
+            @Value("${security.jwt.secret-key}") String secretKey,
+            @Value("${security.jwt.access-token-validity-ms}") Long accessTokenValidityMs) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityMs = accessTokenValidityMs;
+    }
+
+    public String createAccessToken(String subject, Map<String, Object> claims) {
+        return Jwts.builder()
+                .claims(claims) // 커스텀 클레임
+                .subject(subject)
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plusMillis(accessTokenValidityMs)))
+                .signWith(secretKey) // 암호화 알고리즘 자동 감지
+                .compact();
+    }
+
+    public Claims validateTokenAndGetClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/thisway/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/thisway/security/service/CustomUserDetailsService.java
@@ -1,0 +1,34 @@
+package org.thisway.security.service;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thisway.member.entity.Member;
+import org.thisway.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmailAndActiveTrue(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        // TODO: rolse 처리 추가
+        return User
+                .withUsername(member.getEmail())
+                .roles("USER") // 기본 역할 설정, 필요시 수정
+                .password(member.getPassword())
+                .build();
+    }
+
+}

--- a/src/main/java/org/thisway/security/utils/JwtTokenUtil.java
+++ b/src/main/java/org/thisway/security/utils/JwtTokenUtil.java
@@ -1,4 +1,4 @@
-package org.thisway.security.provider;
+package org.thisway.security.utils;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -15,12 +15,12 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
 @Component
-public class JwtTokenProvider {
+public class JwtTokenUtil {
     // TODO : DTO 변경 생각하기.
     private final SecretKey secretKey;
     private final Long accessTokenValidityMs;
 
-    public JwtTokenProvider(
+    public JwtTokenUtil(
             @Value("${security.jwt.secret-key}") String secretKey,
             @Value("${security.jwt.access-token-validity-ms}") Long accessTokenValidityMs) {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/org/thisway/security/SecurityIntegrationTest.java
+++ b/src/test/java/org/thisway/security/SecurityIntegrationTest.java
@@ -1,0 +1,102 @@
+package org.thisway.security;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.thisway.member.entity.Member;
+import org.thisway.member.repository.MemberRepository;
+import org.thisway.security.dto.request.LoginRequest;
+import org.thisway.security.utils.JwtTokenUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder paosswordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    JwtTokenUtil jwtTokenUtil;
+
+    @BeforeEach
+    void setup() {
+        memberRepository.deleteAll();
+        Member member = Member.builder()
+                .name("test")
+                .email("user@example.com")
+                .password(paosswordEncoder.encode("secret"))
+                .phone("01012345678")
+                .memo("")
+                .build();
+
+        memberRepository.save(member);
+    }
+
+    @Test
+    void 로그인_요청_성공() throws Exception {
+        // given :
+        LoginRequest login = new LoginRequest("user@example.com", "secret");
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(login)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                // Authorization 헤더가 존재하고 "Bearer "로 시작하는지 확인
+                .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
+                .andExpect(header().string(HttpHeaders.AUTHORIZATION,
+                        startsWith("Bearer ")));
+    }
+
+    @Test
+    void 인증_토큰_없이_보호된_엔드포인트_접근시_401반환() throws Exception {
+        mockMvc.perform(get("/api/members/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 유효한_토큰으로_보호된_엔드포인트_접근시_200반환() throws Exception {
+        String token = jwtTokenUtil.createAccessToken("testUser", Map.of("roles", List.of("USER")));
+        // String token = jwtTokenUtil.createAccessToken("testUser", Map.of());
+
+        mockMvc.perform(get("/api/members/1")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 변조된_토큰으로_보호된_엔드포인트_접근시_401반환() throws Exception {
+        String badToken = "Bearer this.is.invalid.token";
+
+        mockMvc.perform(get("/api/members/1")
+                .header(HttpHeaders.AUTHORIZATION, badToken))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/org/thisway/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/org/thisway/security/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,150 @@
+package org.thisway.security.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.thisway.security.utils.JwtTokenUtil;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+
+class JwtAuthenticationFilterTest {
+    private MockMvc mockMvc;
+    private JwtTokenUtil jwtTokenProvider;
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = Mockito.mock(JwtTokenUtil.class);
+
+        // 더미 컨트롤러: 필터 통과 시 200 OK
+        @RestController
+        class DummyController {
+            // Dummy controller for testing
+            @GetMapping("/dummy")
+            public void ok() {
+            }
+        }
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new DummyController())
+                .addFilter(new JwtAuthenticationFilter(jwtTokenProvider))
+                .build();
+
+        jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider);
+
+        // 매 테스트 전 컨텍스트 초기화
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 토큰_헤더가_없으면_컨트롤러가_호출되어_200_OK() throws Exception {
+        mockMvc.perform(get("/dummy"))
+                .andExpect(result -> {
+                    assertThat(result
+                            .getResponse()
+                            .getStatus())
+                            .isEqualTo(200);
+                    // SecurityContext는 아무 것도 세팅되지 않아야 함
+                    assertThat(SecurityContextHolder
+                            .getContext()
+                            .getAuthentication())
+                            .isNull();
+                });
+    }
+
+    @Test
+    void 유효한_토큰이면_SecurityContext에_Authentication이_세팅되고_컨트롤러_실행() throws Exception {
+        // given
+        Claims claims = Mockito.mock(Claims.class);
+        given(claims.getSubject())
+                .willReturn("alice");
+        given(claims.get(
+                "roles",
+                List.class))
+                .willReturn(List.of("USER"));
+
+        given(jwtTokenProvider.validateTokenAndGetClaims("valid-token"))
+                .willReturn(claims);
+
+        // when & then
+        mockMvc.perform(get("/dummy")
+                .header("Authorization",
+                        "Bearer valid-token"))
+                .andExpect(result -> {
+                    assertThat(result
+                            .getResponse()
+                            .getStatus()).isEqualTo(200);
+
+                    Authentication auth = SecurityContextHolder
+                            .getContext()
+                            .getAuthentication();
+
+                    assertThat(auth).isNotNull();
+                    assertThat(auth.getName()).isEqualTo("alice");
+                    assertThat(auth.getAuthorities())
+                            .extracting("authority")
+                            .containsExactly("USER");
+                });
+    }
+
+    @Test
+    void 잘못된_JWT로_dummy_요청시_BadCredentialsException_던진다() throws ServletException, IOException {
+        // given : JwtTokenProvider.validateTokenAndGetClaims()가 예외 던지도록 스텁
+        String badToken = "invalid.token.value";
+        given(jwtTokenProvider.validateTokenAndGetClaims(badToken))
+                .willThrow(new BadCredentialsException("Invalid JWT token"));
+
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        req.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + badToken);
+
+        // dummy 체인 : 호출되면 바로 실패
+        FilterChain chain = (r, s) -> {
+            throw new AssertionError("should not reach");
+        };
+
+        // when & then
+        assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(req, res, chain))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessageContaining("Invalid JWT");
+    }
+
+    @Test
+    void 토큰_헤더가_없으면_filterChain이_정상_호출된다() throws ServletException, IOException {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean(false);
+        FilterChain chain = (req, res) -> chainCalled.set(true);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, chain);
+
+        // then
+        assertThat(chainCalled.get()).isTrue(); // 다음 체인으로 정상 진행
+        assertThat(response.getStatus()).isEqualTo(200); // 상태 코드는 기본값(200) 유지
+        assertThat(SecurityContextHolder.getContext().getAuthentication()) // 인증 정보는 세팅되지 않음
+                .isNull();
+    }
+}

--- a/src/test/java/org/thisway/security/provider/JwtTokenProviderAccessTokenTest.java
+++ b/src/test/java/org/thisway/security/provider/JwtTokenProviderAccessTokenTest.java
@@ -1,0 +1,139 @@
+package org.thisway.security.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+
+public class JwtTokenProviderAccessTokenTest {
+
+    private JwtTokenProvider provider;
+
+    private final String secretKey = "this-is-test-string-secret-key-that-is-32-bytes-long";
+    private final long VALIDITY_MS = 60 * 60 * 1000;
+
+    @BeforeEach
+    void setUp() {
+        provider = new JwtTokenProvider(secretKey, VALIDITY_MS);
+    }
+
+    @Test
+    void JWT_AccessToken_생성_및_검증() {
+        // given
+        String username = "testUser";
+        List<String> roles = List.of("USER", "ADMIN");
+        Map<String, Object> claimsMap = Map.of("roles", roles);
+
+        // when
+        String token = provider.createAccessToken(username, claimsMap);
+
+        // then
+        Claims claims = provider.validateTokenAndGetClaims(token);
+        assertThat(claims.getSubject()).isEqualTo(username);
+
+        @SuppressWarnings("unchecked")
+        List<String> tokenRoles = claims.get("roles", List.class);
+
+        // tokenRoles 리스트가 roles 리스트와 "같은 원소를 모두 포함"하고 있는지, "순서와 중복은 무시"하고 검사
+        assertThat(tokenRoles).containsExactlyInAnyOrderElementsOf(roles);
+    }
+
+    @Test
+    void 만료된_JWT_AccessToken에_대한_검증_실패() {
+        // given: 만료 시간을 0으로 설정한 Provider
+        JwtTokenProvider shortLived = new JwtTokenProvider(secretKey, 0L);
+        String shortToken = shortLived.createAccessToken("user", Map.of());
+
+        // when: 생성되자 말자 token 만료됨.
+
+        // then
+        assertThrows(
+                JwtException.class,
+                () -> shortLived.validateTokenAndGetClaims(shortToken));
+    }
+
+    @Test
+    void 토큰이_발급한_시점과_만료_시점_사이의_간격이_설정한_유효기간과_일치확인() {
+        // given
+        Instant before = Instant.now();
+        String token = provider.createAccessToken("u", Map.of());
+        Claims c = provider.validateTokenAndGetClaims(token);
+
+        // when
+        Instant issuedAt = c.getIssuedAt().toInstant();
+        Instant expiresAt = c.getExpiration().toInstant();
+        Duration actual = Duration.between(issuedAt, expiresAt);
+
+        // then
+        // 유효기간이 1시간으로 설정되어 있으므로, 1시간(3600초)과 비교
+        Duration expected = Duration.ofMillis(VALIDITY_MS);
+        assertThat(actual)
+                .isCloseTo(expected, Duration.ofSeconds(1L));
+
+        // 발급 시각 타이밍 검증
+        assertThat(issuedAt)
+                .isBetween(before.minusSeconds(1),
+                        Instant.now().plusSeconds(1));
+    }
+
+    @Test
+    void 서명이_변조된_토큰_검증시_JwtException_발생() {
+        // given: 정상 토큰 생성
+        String token = provider.createAccessToken("user", Map.of("foo", "bar"));
+
+        // 토큰은 헤더.페이로드.서명 3파트로 구성되어 있음
+        String[] parts = token.split("\\.");
+        String header = parts[0];
+        String payload = parts[1];
+        String signature = parts[2];
+
+        // when: 서명 부분만 임의로 변경
+        String tamperedSignature = signature + "xyz";
+        String tamperedToken = header + "." + payload + "." + tamperedSignature;
+
+        // then: 서명 불일치로 JwtException 발생
+        assertThrows(JwtException.class,
+                () -> provider.validateTokenAndGetClaims(tamperedToken));
+    }
+
+    @Test
+    void 서로_다른_서명키로_발급된_토큰_검증시_JwtException_발생() {
+        // given: 두 개의 프로바이더, 서로 다른 시크릿
+        // JwtTokenProvider p1 = new
+        // JwtTokenProvider("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", VALIDITY_MS);
+        JwtTokenProvider p1 = new JwtTokenProvider("A".repeat(16),
+                VALIDITY_MS);
+
+        JwtTokenProvider p2 = new JwtTokenProvider("B".repeat(16), VALIDITY_MS);
+
+        String token = p1.createAccessToken("alice", Map.of("foo", "bar"));
+
+        // then: p2로 파싱 시 서명 불일치
+        assertThrows(JwtException.class,
+                () -> p2.validateTokenAndGetClaims(token));
+    }
+
+    // @Test
+    // void validateTokenAndGetClaims_토큰이_null_또는_빈값이면_예외_발생() {
+    // // assertAll(
+    // // () -> assertThrows(
+    // // IllegalArgumentException.class,
+    // // () -> provider.validateTokenAndGetClaims(null)),
+    // // () -> assertThrows(
+    // // JwtException.class,
+    // // () -> provider.validateTokenAndGetClaims("")));
+    // assertThrows(
+    // JwtException.class,
+    // () -> provider.validateTokenAndGetClaims(""));
+    // }
+    // TODO : JWT 토큰에 대해 추가적인 테스트 해야함.
+}

--- a/src/test/java/org/thisway/security/provider/JwtTokenProviderTest.java
+++ b/src/test/java/org/thisway/security/provider/JwtTokenProviderTest.java
@@ -11,20 +11,21 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.thisway.security.utils.JwtTokenUtil;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 
 public class JwtTokenProviderTest {
 
-    private JwtTokenProvider provider;
+    private JwtTokenUtil provider;
 
     private final String secretKey = "this-is-test-string-secret-key-that-is-32-bytes-long";
     private final long VALIDITY_MS = 60 * 60 * 1000;
 
     @BeforeEach
     void setUp() {
-        provider = new JwtTokenProvider(secretKey, VALIDITY_MS);
+        provider = new JwtTokenUtil(secretKey, VALIDITY_MS);
     }
 
     @Test
@@ -51,7 +52,7 @@ public class JwtTokenProviderTest {
     @Test
     void 만료된_JWT_AccessToken에_대한_검증_실패() {
         // given: 만료 시간을 0으로 설정한 Provider
-        JwtTokenProvider shortLived = new JwtTokenProvider(secretKey, 0L);
+        JwtTokenUtil shortLived = new JwtTokenUtil(secretKey, 0L);
         String shortToken = shortLived.createAccessToken("user", Map.of());
 
         // when: 생성되자 말자 token 만료됨.
@@ -111,9 +112,9 @@ public class JwtTokenProviderTest {
         // given: 두 개의 프로바이더, 서로 다른 시크릿
         // JwtTokenProvider p1 = new
         // JwtTokenProvider("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", VALIDITY_MS);
-        JwtTokenProvider p1 = new JwtTokenProvider("A".repeat(32), VALIDITY_MS);
+        JwtTokenUtil p1 = new JwtTokenUtil("A".repeat(32), VALIDITY_MS);
 
-        JwtTokenProvider p2 = new JwtTokenProvider("B".repeat(32), VALIDITY_MS);
+        JwtTokenUtil p2 = new JwtTokenUtil("B".repeat(32), VALIDITY_MS);
 
         String token = p1.createAccessToken("alice", Map.of("foo", "bar"));
 

--- a/src/test/java/org/thisway/security/provider/JwtTokenProviderTest.java
+++ b/src/test/java/org/thisway/security/provider/JwtTokenProviderTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 
-public class JwtTokenProviderAccessTokenTest {
+public class JwtTokenProviderTest {
 
     private JwtTokenProvider provider;
 
@@ -30,7 +30,7 @@ public class JwtTokenProviderAccessTokenTest {
     void JWT_AccessToken_생성_및_검증() {
         // given
         String username = "testUser";
-        List<String> roles = List.of("USER", "ADMIN");
+        List<String> roles = List.of("ROLE_USER", "ROLE_ADMIN");
         Map<String, Object> claimsMap = Map.of("roles", roles);
 
         // when
@@ -110,10 +110,9 @@ public class JwtTokenProviderAccessTokenTest {
         // given: 두 개의 프로바이더, 서로 다른 시크릿
         // JwtTokenProvider p1 = new
         // JwtTokenProvider("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", VALIDITY_MS);
-        JwtTokenProvider p1 = new JwtTokenProvider("A".repeat(16),
-                VALIDITY_MS);
+        JwtTokenProvider p1 = new JwtTokenProvider("A".repeat(16), VALIDITY_MS);
 
-        JwtTokenProvider p2 = new JwtTokenProvider("B".repeat(16), VALIDITY_MS);
+        JwtTokenProvider p2 = new JwtTokenProvider("B", VALIDITY_MS);
 
         String token = p1.createAccessToken("alice", Map.of("foo", "bar"));
 

--- a/src/test/java/org/thisway/security/provider/JwtTokenProviderTest.java
+++ b/src/test/java/org/thisway/security/provider/JwtTokenProviderTest.java
@@ -1,6 +1,7 @@
 package org.thisway.security.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Duration;
@@ -110,9 +111,9 @@ public class JwtTokenProviderTest {
         // given: 두 개의 프로바이더, 서로 다른 시크릿
         // JwtTokenProvider p1 = new
         // JwtTokenProvider("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", VALIDITY_MS);
-        JwtTokenProvider p1 = new JwtTokenProvider("A".repeat(16), VALIDITY_MS);
+        JwtTokenProvider p1 = new JwtTokenProvider("A".repeat(32), VALIDITY_MS);
 
-        JwtTokenProvider p2 = new JwtTokenProvider("B", VALIDITY_MS);
+        JwtTokenProvider p2 = new JwtTokenProvider("B".repeat(32), VALIDITY_MS);
 
         String token = p1.createAccessToken("alice", Map.of("foo", "bar"));
 
@@ -121,18 +122,28 @@ public class JwtTokenProviderTest {
                 () -> p2.validateTokenAndGetClaims(token));
     }
 
-    // @Test
-    // void validateTokenAndGetClaims_토큰이_null_또는_빈값이면_예외_발생() {
-    // // assertAll(
-    // // () -> assertThrows(
-    // // IllegalArgumentException.class,
-    // // () -> provider.validateTokenAndGetClaims(null)),
-    // // () -> assertThrows(
-    // // JwtException.class,
-    // // () -> provider.validateTokenAndGetClaims("")));
-    // assertThrows(
-    // JwtException.class,
-    // () -> provider.validateTokenAndGetClaims(""));
-    // }
-    // TODO : JWT 토큰에 대해 추가적인 테스트 해야함.
+    @Test
+    void 토큰이_null_또는_빈값이면_IllegalArgument예외_발생() {
+        assertAll(
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> provider.validateTokenAndGetClaims(null)),
+                () -> assertThrows(
+                        IllegalArgumentException.class,
+                        () -> provider.validateTokenAndGetClaims("")));
+    }
+
+    @Test
+    void 형식이_올바르지_않은_토큰_검증시_JwtException_발생() {
+        // given: 마침표가 2개가 아닌 잘못된 형식
+        String badFormatToken = "invalid.token";
+        // given: 올바르지 않은 토큰
+        String badToken = "invalid.token.value";
+
+        // when / then
+        assertThrows(JwtException.class,
+                () -> provider.validateTokenAndGetClaims(badFormatToken));
+        assertThrows(JwtException.class,
+                () -> provider.validateTokenAndGetClaims(badToken));
+    }
 }

--- a/src/test/java/org/thisway/vehicle/controller/VehicleControllerTest.java
+++ b/src/test/java/org/thisway/vehicle/controller/VehicleControllerTest.java
@@ -1,18 +1,34 @@
 // java
 package org.thisway.vehicle.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
@@ -22,19 +38,10 @@ import org.thisway.vehicle.dto.response.VehicleResponse;
 import org.thisway.vehicle.dto.response.VehiclesResponse;
 import org.thisway.vehicle.service.VehicleService;
 
-import java.util.List;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@WebMvcTest(VehicleController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 class VehicleControllerTest {
 
     @Autowired
@@ -55,6 +62,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 등록 요청 성공")
+    @WithMockUser
     void 차량_등록_요청_성공() throws Exception {
         VehicleCreateRequest request = new VehicleCreateRequest(
                 "현대", 2022, "아반떼", "12가3456", "흰색",
@@ -62,10 +70,9 @@ class VehicleControllerTest {
         doNothing().when(vehicleService).registerVehicle(request);
 
         mockMvc.perform(
-                        post("/api/vehicles")
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(request))
-                )
+                post("/api/vehicles")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("201"));
@@ -73,18 +80,18 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 등록 요청 실패 - 업체 미존재")
+    @WithMockUser
     void 차량_등록_요청_실패() throws Exception {
         VehicleCreateRequest request = new VehicleCreateRequest(
                 "현대", 2022, "아반떼", "12가3456", "흰색",
-                1000,37.5665, 126.9780);
+                1000, 37.5665, 126.9780);
         doThrow(new CustomException(ErrorCode.COMPANY_NOT_FOUND))
                 .when(vehicleService).registerVehicle(request);
 
         mockMvc.perform(
-                        post("/api/vehicles")
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(request))
-                )
+                post("/api/vehicles")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("회사 정보를 찾을 수 없습니다."));
@@ -92,6 +99,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 상세 조회 API 성공")
+    @WithMockUser
     void 차량_상세_조회_성공() throws Exception {
         // given
         Long vehicleId = 1L;
@@ -104,13 +112,12 @@ class VehicleControllerTest {
                 "샘플 회사",
                 "34나5678",
                 "검정",
-                10000
-        );
+                10000);
         given(vehicleService.getVehicleDetail(vehicleId)).willReturn(vehicleResponse);
 
         // when & then
         mockMvc.perform(get("/api/vehicles/{id}", vehicleId)
-                        .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
@@ -124,6 +131,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 상세 조회 API 실패 - 차량 없음")
+    @WithMockUser
     void 차량_상세_조회_실패() throws Exception {
         // given
         Long vehicleId = 1L;
@@ -132,7 +140,7 @@ class VehicleControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/vehicles/{id}", vehicleId)
-                        .contentType(MediaType.APPLICATION_JSON))
+                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(ErrorCode.VEHICLE_NOT_FOUND.getStatusValue()))
@@ -142,12 +150,12 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 삭제 요청 성공")
+    @WithMockUser
     void 차량_삭제_요청_성공() throws Exception {
         doNothing().when(vehicleService).deleteVehicle(1L);
 
         mockMvc.perform(
-                        delete("/api/vehicles/1")
-                )
+                delete("/api/vehicles/1"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("204"));
@@ -155,13 +163,13 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 삭제 요청 실패 - 차량 미존재")
+    @WithMockUser
     void 차량_삭제_요청_실패() throws Exception {
         doThrow(new CustomException(ErrorCode.VEHICLE_NOT_FOUND))
                 .when(vehicleService).deleteVehicle(1L);
 
         mockMvc.perform(
-                        delete("/api/vehicles/1")
-                )
+                delete("/api/vehicles/1"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("차량 정보를 조회할 수 없습니다."));
@@ -169,6 +177,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 삭제 요청 실패 - 이미 삭제된 차량")
+    @WithMockUser
     void 이미_삭제된_차량_삭제_요청_실패() throws Exception {
         // given
         doThrow(new CustomException(ErrorCode.VEHICLE_ALREADY_DELETED))
@@ -176,8 +185,7 @@ class VehicleControllerTest {
 
         // when & then
         mockMvc.perform(
-                        delete("/api/vehicles/1")
-                )
+                delete("/api/vehicles/1"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("400"))
@@ -186,12 +194,12 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 목록 조회 성공 - 기본 페이지네이션")
+    @WithMockUser
     void 차량_목록_조회_성공_기본_페이지네이션() throws Exception {
         // given
         List<VehicleResponse> vehicles = List.of(
                 new VehicleResponse(1L, "현대", 2023, "아반떼", 1L, "샘플 회사", "12가3456", "검정", 5000),
-                new VehicleResponse(2L, "기아", 2023, "K5", 1L, "샘플 회사", "34나5678", "흰색", 3000)
-        );
+                new VehicleResponse(2L, "기아", 2023, "K5", 1L, "샘플 회사", "34나5678", "흰색", 3000));
         VehiclesResponse response = new VehiclesResponse(vehicles, 1, 2, 0, 10);
 
         given(vehicleService.getVehicles(any())).willReturn(response);
@@ -209,11 +217,11 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 목록 조회 성공 - 두 번째 페이지")
+    @WithMockUser
     void 차량_목록_조회_성공_두번째_페이지() throws Exception {
         // given
         List<VehicleResponse> vehicles = List.of(
-                new VehicleResponse(3L, "쌍용", 2023, "티볼리", 1L, "샘플 회사", "56다7890", "파랑", 1000)
-        );
+                new VehicleResponse(3L, "쌍용", 2023, "티볼리", 1L, "샘플 회사", "56다7890", "파랑", 1000));
         Page<VehicleResponse> page = new PageImpl<>(vehicles);
         VehiclesResponse response = new VehiclesResponse(vehicles, 2, 3, 1, 2);
 
@@ -221,8 +229,8 @@ class VehicleControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/vehicles")
-                        .param("page", "3")
-                        .param("size", "2"))
+                .param("page", "3")
+                .param("size", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.vehicles").isArray())
                 .andExpect(jsonPath("$.data.vehicles.length()").value(1))
@@ -234,23 +242,22 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 목록 조회 성공 - 정렬 적용")
+    @WithMockUser
     void 차량_목록_조회_성공_정렬_적용() throws Exception {
         // given
         List<VehicleResponse> descendingOrder = List.of(
                 new VehicleResponse(2L, "기아", 2023, "K5", 1L, "샘플 회사", "34나5678", "흰색", 3000),
-                new VehicleResponse(1L, "현대", 2023, "아반떼", 1L, "샘플 회사", "12가3456", "검정", 5000)
-        );
+                new VehicleResponse(1L, "현대", 2023, "아반떼", 1L, "샘플 회사", "12가3456", "검정", 5000));
 
         VehiclesResponse descResponse = new VehiclesResponse(descendingOrder, 1, 2, 0, 10);
 
-        given(vehicleService.getVehicles(argThat(pageable ->
-                pageable.getSort().getOrderFor("carNumber") != null &&
-                        pageable.getSort().getOrderFor("carNumber").getDirection().isDescending())))
+        given(vehicleService.getVehicles(argThat(pageable -> pageable.getSort().getOrderFor("carNumber") != null &&
+                pageable.getSort().getOrderFor("carNumber").getDirection().isDescending())))
                 .willReturn(descResponse);
 
         // when & then
         mockMvc.perform(get("/api/vehicles")
-                        .param("sort", "carNumber,desc"))
+                .param("sort", "carNumber,desc"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.vehicles").isArray())
@@ -261,6 +268,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 정보 수정 요청 성공")
+    @WithMockUser
     void 차량_정보_수정_요청_성공() throws Exception {
         // given
         Long vehicleId = 1L;
@@ -269,16 +277,14 @@ class VehicleControllerTest {
                 "흰색",
                 "기아",
                 2024,
-                "K5"
-        );
+                "K5");
         doNothing().when(vehicleService).updateVehicle(vehicleId, request);
 
         // when & then
         mockMvc.perform(
-                        patch("/api/vehicles/{id}", vehicleId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
+                patch("/api/vehicles/{id}", vehicleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("204"));
@@ -286,6 +292,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 정보 수정 요청 실패 - 차량을 찾을 수 없음")
+    @WithMockUser
     void 차량_정보_수정_요청_실패_차량_미존재() throws Exception {
         // given
         Long vehicleId = 999L;
@@ -294,17 +301,15 @@ class VehicleControllerTest {
                 "흰색",
                 "기아",
                 2024,
-                "K5"
-        );
+                "K5");
         doThrow(new CustomException(ErrorCode.VEHICLE_NOT_FOUND))
                 .when(vehicleService).updateVehicle(vehicleId, request);
 
         // when & then
         mockMvc.perform(
-                        patch("/api/vehicles/{id}", vehicleId)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
-                )
+                patch("/api/vehicles/{id}", vehicleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(ErrorCode.VEHICLE_NOT_FOUND.getStatusValue()))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,3 +35,8 @@ spring:
 
 custom:
   auth-code-expiration-millis: 600000
+
+security:
+  jwt:
+    secret-key: szU3FELDRTw9sJzzP1cWuo/xUzIjSvMGGSWKlMCgku/vZwsSmi8BHsH/rnsAyTzTAQ2IGS0mgr/oxi4WsHMhcQ==
+    access-token-validity-ms: 360000


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 📌 관련 이슈
- #6
- #7
- #45
- #46 
- #60 
- #61 
- #63
- #64
- #66 
- #67

### ✨ 반영 브랜치
feat/7 -> develop

### 📝 변경 사항
- [ ] Spring Security 관련 설정
- [ ] JWT 발행 및 검증 
- [ ] /api/auth를 제외한 모든 API 호출 시 JWT 검증
- [ ] Member 저장 시 비밀번호 인코딩 후 저장

### ➕ 추가 메모
- role에 따른 접근 권한 분리 X
- 인증/인가에서 발생하는 예외처리 응답 포맷이 공통 응답 포맷과 불일치
- `JwtTokenProvider` -> `JwtTokenUtil` 명으로 변경,
  - 이로인해 기존에 Provider로 작성된 코드들이 남아있음(ex, `JwtProviderTest.java`)
  - 이후 리팩토링 과정에서 수정할 예정
- Refresh Token 기능은 추후 의논 후 도입 예정
- 기능별로 테스트 코드 작성 미흡 -> 이로인해 에러 발생확률 높음
- formatter로 인해 수정되지 않은 부분도 Diff발생 -> 추후 수정 예정
- JWT Secret Key는 openssl로 테스트 용으로 생성했으므로 노출되어도 상관X
- Spring Security 의존성 추가로 인해 기존의 테스트 코드 안되는 경우 발생
 - Default Spring Security Config가 자동 로드됨

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
<img width="556" alt="image" src="https://github.com/user-attachments/assets/321328c0-bded-408e-a8d5-44b078c8f598" />

