### PR TITLE
Member 엔티티 role 추가 및 인증 적용

### DIFF
--- a/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
+++ b/src/main/java/org/thisway/member/dto/request/MemberRegisterRequest.java
@@ -4,10 +4,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.thisway.company.entity.Company;
 import org.thisway.member.entity.Member;
+import org.thisway.member.entity.MemberRole;
 
 public record MemberRegisterRequest(
 
         @NotNull Long companyId,
+
+        @NotNull MemberRole role,
 
         @NotBlank String name,
 
@@ -22,6 +25,7 @@ public record MemberRegisterRequest(
     public Member toMember(Company company, String encodedPassword) {
         return Member.builder()
                 .company(company)
+                .role(role)
                 .name(name)
                 .email(email)
                 .password(encodedPassword)

--- a/src/main/java/org/thisway/member/dto/response/MemberResponse.java
+++ b/src/main/java/org/thisway/member/dto/response/MemberResponse.java
@@ -1,10 +1,12 @@
 package org.thisway.member.dto.response;
 
 import org.thisway.member.entity.Member;
+import org.thisway.member.entity.MemberRole;
 
 public record MemberResponse(
         Long id,
         Long companyId,
+        MemberRole role,
         String name,
         String email,
         String phone,
@@ -15,6 +17,7 @@ public record MemberResponse(
         return new MemberResponse(
                 member.getId(),
                 member.getCompany().getId(),
+                member.getRole(),
                 member.getName(),
                 member.getEmail(),
                 member.getPhoneValue(),

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -4,6 +4,8 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -17,12 +19,15 @@ import org.thisway.company.entity.Company;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-// todo: 인증/인가 구현 후 역할 컬럼 추가
 public class Member extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "company_id", nullable = false)
     private Company company;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    MemberRole role;
 
     @Column(nullable = false)
     private String name;
@@ -43,6 +48,7 @@ public class Member extends BaseEntity {
     @Builder
     public Member(
             Company company,
+            MemberRole role,
             String name,
             String email,
             String password,
@@ -50,6 +56,7 @@ public class Member extends BaseEntity {
             String memo
     ) {
         this.company = company;
+        this.role = role;
         this.name = name;
         this.email = email;
         this.password = password;

--- a/src/main/java/org/thisway/member/entity/MemberRole.java
+++ b/src/main/java/org/thisway/member/entity/MemberRole.java
@@ -1,0 +1,9 @@
+package org.thisway.member.entity;
+
+public enum MemberRole {
+
+    ADMIN,
+    COMPANY_ADMIN,
+    COMPANY_CHEF,
+    MEMBER,
+}

--- a/src/main/java/org/thisway/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/thisway/security/service/CustomUserDetailsService.java
@@ -23,10 +23,9 @@ public class CustomUserDetailsService implements UserDetailsService {
         Member member = memberRepository.findByEmailAndActiveTrue(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
 
-        // TODO: rolse 처리 추가
         return User
                 .withUsername(member.getEmail())
-                .roles("USER") // 기본 역할 설정, 필요시 수정
+                .roles(member.getRole().name())
                 .password(member.getPassword())
                 .build();
     }

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -11,12 +11,14 @@ import org.thisway.member.dto.request.MemberRegisterRequest;
 import org.thisway.member.dto.response.MemberResponse;
 import org.thisway.member.dto.response.MembersResponse;
 import org.thisway.member.entity.Member;
+import org.thisway.member.entity.MemberRole;
 
 public class MemberFixture {
 
     public static MemberRegisterRequest createMemberRegisterRequestWithCompanyId(long companyId) {
         return new MemberRegisterRequest(
                 companyId,
+                MemberRole.MEMBER,
                 "홍길동",
                 "hong@example.com",
                 "Password123!",
@@ -28,6 +30,7 @@ public class MemberFixture {
     public static MemberRegisterRequest createMemberRegisterRequestWithCompanyIdAndEmail(long companyId, String email) {
         return new MemberRegisterRequest(
                 companyId,
+                MemberRole.MEMBER,
                 "홍길동",
                 email,
                 "Password123!",
@@ -39,6 +42,7 @@ public class MemberFixture {
     public static Member createMember(Company company) {
         return Member.builder()
                 .company(company)
+                .role(MemberRole.MEMBER)
                 .name("홍길동")
                 .email("hong@example.com")
                 .password("Password123!")
@@ -50,6 +54,7 @@ public class MemberFixture {
     public static Member createMemberWithEmail(Company company, String email) {
         return Member.builder()
                 .company(company)
+                .role(MemberRole.MEMBER)
                 .name("홍길동")
                 .email(email)
                 .password("Password123!")
@@ -62,6 +67,7 @@ public class MemberFixture {
         return new MemberResponse(
                 1L,
                 1L,
+                MemberRole.MEMBER,
                 "홍길동",
                 "hong@example.com",
                 "01012345678",


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #69 

### ✨ 반영 브랜치
- feat/69 -> develop

### 📝 변경 사항
- 멤버 엔티티에 role 추가
- 인증 발급시 실제 role 적용

### ➕ 추가 메모
- MemberRole enum의 name값들을 회의에 나왔던 'CHEF'를 이용해서 작명했습니다!
- 임시로 작명한 것이라 의견 주시면 감사하겠습니다!

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
다음 데이터가 들어있을 때,
```
+----+----------------+----------------------------+----------------------------+-------+------+------+--------------------------------------------------------------+-------------+------------+-------+
| id | active         | created_at                 | updated_at                 | email | memo | name | password                                                     | phone       | company_id | role  |
+----+----------------+----------------------------+----------------------------+-------+------+------+--------------------------------------------------------------+-------------+------------+-------+
| 21 | 0x01           | 2025-05-31 07:48:36.693236 | 2025-05-31 07:48:36.693258 | email | memo | name | $2a$10$F9tPmrcaHIbrz8a/YbJT7OY/dx430d.P1GdQPyeyhDkDlhKxvWg6e | 01012347914 |          1 | ADMIN |
+----+----------------+----------------------------+----------------------------+-------+------+------+--------------------------------------------------------------+-------------+------------+-------+
```

login 후 JWT decoding 결과입니다.
```json
{
  "ROLE_ADMIN": true,
  "sub": "email",
  "iat": 1748678426,
  "exp": 1748678786
}
```