### PR TITLE
feat: #71 JWT Header에서 Body로 반환

### DIFF
--- a/src/main/java/org/thisway/security/handler/JsonAuthenticationSuccessHandler.java
+++ b/src/main/java/org/thisway/security/handler/JsonAuthenticationSuccessHandler.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.thisway.security.utils.JwtTokenUtil;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,7 +30,6 @@ public class JsonAuthenticationSuccessHandler implements AuthenticationSuccessHa
             HttpServletRequest request,
             HttpServletResponse response,
             Authentication authentication) throws IOException, ServletException {
-        // Handle successful authentication
         String subject = authentication.getName();
         Map<String, Object> claims = new HashMap<>();
 
@@ -38,14 +39,19 @@ public class JsonAuthenticationSuccessHandler implements AuthenticationSuccessHa
                         auth.getAuthority(),
                         true));
 
-        // log.info("Authentication successful for user: {} {}", subject,
-        // authentication.getAuthorities());
-        log.info("creating JWT for user: {} with claims: {}", subject, claims);
-
         String jwt = jwtTokenUtil.createAccessToken(subject, claims);
 
         response.setStatus(HttpServletResponse.SC_OK);
-        response.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwt);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, String> payload = new HashMap<>();
+        payload.put("token", jwt);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(payload);
+        response.getWriter().write(json);
+        response.getWriter().flush();
     }
 
 }

--- a/src/test/java/org/thisway/security/SecurityIntegrationTest.java
+++ b/src/test/java/org/thisway/security/SecurityIntegrationTest.java
@@ -1,11 +1,10 @@
 package org.thisway.security;
 
-import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
@@ -70,8 +69,7 @@ class SecurityIntegrationTest {
                 .content(objectMapper.writeValueAsString(login)))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
-                .andExpect(header().string(HttpHeaders.AUTHORIZATION, startsWith("Bearer ")));
+                .andExpect(jsonPath("$.token").isString());
     }
 
     @Test
@@ -88,8 +86,7 @@ class SecurityIntegrationTest {
 
         mockMvc.perform(
                 get("/api/members/1")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-                )
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
                 .andExpect(status().isOk());
     }
 


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가


### 📌 관련 이슈
#71 

### ✨ 반영 브랜치
ex) feat/72 -> develop

### 📝 변경 사항
- [x] JWT를 Header에 담아서 보냈는데 Body로 보내도록 변경
- [x] 이에 맞게 Test 코드 수정

### ➕ 추가 메모
- Body로 담으면 응답 메시지에 추가적인 부분을 넣기 수월함(만료시간)
- 중간 계층(프록시 등)에서 헤더가 사라질 위험이 있음.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
