### PR TITLE
업체 최고 담당자의 Member 전체 조회시 업체 및 권한 필터링 기능 추가

### DIFF
--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
 
     // 인증 에러 x3xxx
     AUTH_INVALID_VERIFY_CODE("13000","잘못된 인증코드입니다.", HttpStatus.BAD_REQUEST),
+    AUTH_UNAUTHENTICATED("13001","인증된 사용자가 아닙니다.", HttpStatus.UNAUTHORIZED),
+    AUTH_INVALID_AUTHENTICATION("13002","잘못된 인증정보입니다.", HttpStatus.UNAUTHORIZED),
 
     // 차량 x4xxx
     VEHICLE_NOT_FOUND("14000", "차량 정보를 조회할 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/org/thisway/member/entity/Member.java
+++ b/src/main/java/org/thisway/member/entity/Member.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,5 +71,9 @@ public class Member extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public Set<MemberRole> getLowerOrEqualRoles() {
+        return role.getLowerOrEqualRoles();
     }
 }

--- a/src/main/java/org/thisway/member/entity/MemberRole.java
+++ b/src/main/java/org/thisway/member/entity/MemberRole.java
@@ -1,9 +1,26 @@
 package org.thisway.member.entity;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum MemberRole {
 
-    ADMIN,
-    COMPANY_ADMIN,
-    COMPANY_CHEF,
-    MEMBER,
+    ADMIN(4),
+    COMPANY_ADMIN(3),
+    COMPANY_CHEF(2),
+    MEMBER(1),
+    ;
+
+    private final int level;
+
+    public Set<MemberRole> getLowerOrEqualRoles() {
+        return Arrays.stream(MemberRole.values())
+                .filter(role -> role.level <= this.level)
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/org/thisway/member/repository/MemberRepository.java
+++ b/src/main/java/org/thisway/member/repository/MemberRepository.java
@@ -1,16 +1,20 @@
 package org.thisway.member.repository;
 
+import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.thisway.company.entity.Company;
 import org.thisway.member.entity.Member;
-
-import java.util.Optional;
+import org.thisway.member.entity.MemberRole;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndActiveTrue(String email);
 
+    boolean existsByEmail(String email);
+
     Page<Member> findAllByActiveTrue(Pageable pageable);
 
-    boolean existsByEmail(String email);
+    Page<Member> findAllByActiveTrueAndRoleInAndCompany(Set<MemberRole> roles, Company company, Pageable pageable);
 }

--- a/src/main/java/org/thisway/security/service/SecurityService.java
+++ b/src/main/java/org/thisway/security/service/SecurityService.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.member.entity.Member;
@@ -12,6 +13,7 @@ import org.thisway.member.repository.MemberRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class SecurityService {
 
     private final MemberRepository memberRepository;
@@ -30,6 +32,7 @@ public class SecurityService {
         return (UserDetails) authentication.getPrincipal();
     }
 
+    @Transactional(readOnly = true)
     public Member getCurrentMember() {
         return memberRepository.findByEmailAndActiveTrue(getCurrentUserDetails().getUsername())
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_INVALID_AUTHENTICATION));

--- a/src/main/java/org/thisway/security/service/SecurityService.java
+++ b/src/main/java/org/thisway/security/service/SecurityService.java
@@ -1,0 +1,37 @@
+package org.thisway.security.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+import org.thisway.member.entity.Member;
+import org.thisway.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SecurityService {
+
+    private final MemberRepository memberRepository;
+
+    private UserDetails getCurrentUserDetails() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || authentication.getPrincipal() == null
+                || !(authentication.getPrincipal() instanceof UserDetails)
+        ) {
+            throw new CustomException(ErrorCode.AUTH_UNAUTHENTICATED);
+        }
+
+        return (UserDetails) authentication.getPrincipal();
+    }
+
+    public Member getCurrentMember() {
+        return memberRepository.findByEmailAndActiveTrue(getCurrentUserDetails().getUsername())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_INVALID_AUTHENTICATION));
+    }
+}

--- a/src/test/java/org/thisway/member/support/MemberFixture.java
+++ b/src/test/java/org/thisway/member/support/MemberFixture.java
@@ -51,10 +51,34 @@ public class MemberFixture {
                 .build();
     }
 
+    public static Member createMember(Company company, MemberRole role) {
+        return Member.builder()
+                .company(company)
+                .role(role)
+                .name("홍길동")
+                .email("hong@example.com")
+                .password("Password123!")
+                .phone("01012345678")
+                .memo("가입 메모")
+                .build();
+    }
+
     public static Member createMemberWithEmail(Company company, String email) {
         return Member.builder()
                 .company(company)
                 .role(MemberRole.MEMBER)
+                .name("홍길동")
+                .email(email)
+                .password("Password123!")
+                .phone("01012345678")
+                .memo("가입 메모")
+                .build();
+    }
+
+    public static Member createMemberWithEmail(Company company, MemberRole role, String email) {
+        return Member.builder()
+                .company(company)
+                .role(role)
                 .name("홍길동")
                 .email(email)
                 .password("Password123!")

--- a/src/test/java/org/thisway/security/service/SecurityServiceTest.java
+++ b/src/test/java/org/thisway/security/service/SecurityServiceTest.java
@@ -1,0 +1,97 @@
+package org.thisway.security.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+import org.thisway.member.entity.Member;
+import org.thisway.member.repository.MemberRepository;
+
+class SecurityServiceTest {
+
+    private MemberRepository memberRepository;
+    private SecurityService securityService;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = mock(MemberRepository.class);
+        securityService = new SecurityService(memberRepository);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("인증된 사용자의 Member 정보를 성공적으로 조회할 수 있다.")
+    void 현재_회원_조회_성공() {
+        // given
+        String email = "email@example.com";
+        UserDetails user = new User(email, "password", new ArrayList<>());
+        Member member = mock(Member.class);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities())
+        );
+
+        when(memberRepository.findByEmailAndActiveTrue(email))
+                .thenReturn(Optional.of(member));
+
+        // when
+        Member result = securityService.getCurrentMember();
+
+        // then
+        assertThat(result).isEqualTo(member);
+        verify(memberRepository).findByEmailAndActiveTrue(email);
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 상태에서 현재 회원 정보를 조회하면 예외가 발생한다.")
+    void 현재_회원_조회_실패_인증안됨() {
+        // given
+        SecurityContextHolder.clearContext(); // 인증정보 없음
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                securityService.getCurrentMember()
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_UNAUTHENTICATED);
+    }
+
+    @Test
+    @DisplayName("인증정보는 있으나 해당 사용자가 존재하지 않을 경우 예외가 발생한다.")
+    void 현재_회원_조회_실패_DB에_없음() {
+        // given
+        String email = "email@example.com";
+        UserDetails user = new User(email, "password", new ArrayList<>());
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities())
+        );
+
+        when(memberRepository.findByEmailAndActiveTrue(email)).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                securityService.getCurrentMember()
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_AUTHENTICATION);
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
- #29 

### ✨ 반영 브랜치
feat/29 -> develop

### 📝 변경 사항
- 현재 인증 멤버 가져오기 기능 추가
- 멤버 조회시 권한 및 업체 고려하도록 변경
  - ADMIN: 전체 조회
  - 나머지 권한: 하위 권한, 본인 업체만 조회
 
### ➕ 추가 메모

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
![테스트 성공 스크린샷](https://github.com/user-attachments/assets/4be7f103-824c-42dc-8cda-8af2cd329a76)
