### PR TITLE
Refactor/128 : Vehicle 등록 형식 변경

### DIFF
--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     VEHICLE_DUPLICATE_CAR_NUMBER("14002", "이미 등록된 차량 번호입니다", HttpStatus.BAD_REQUEST),
     VEHICLE_EMPTY_UPDATE_REQUEST("14003", "업데이트할 정보가 없습니다.", HttpStatus.BAD_REQUEST),
     VEHICLE_MODEL_ALREADY_EXISTS("14004", "이미 등록된 차량 모델입니다.", HttpStatus.BAD_REQUEST),
+    VEHICLE_MODEL_NOT_FOUND("14005", "차량 모델을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
 
     // 에뮬레이터 x5xxx
     EMULATOR_NOT_FOUND("15000", "존재하지 않는 에뮬레이터입니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/org/thisway/vehicle/dto/request/VehicleCreateRequest.java
+++ b/src/main/java/org/thisway/vehicle/dto/request/VehicleCreateRequest.java
@@ -9,14 +9,8 @@ import org.thisway.vehicle.entity.VehicleModel;
 
 public record VehicleCreateRequest(
 
-        @NotBlank
-        String manufacturer,
-
         @NotNull
-        Integer modelYear,
-
-        @NotBlank
-        String name,
+        Long vehicleModelId,
 
         @NotBlank
         @ValidCarNumber
@@ -25,14 +19,6 @@ public record VehicleCreateRequest(
         @NotBlank
         String color
 ) {
-        public VehicleModel toVehicleModelEntity() {
-                return VehicleModel.builder()
-                        .manufacturer(this.manufacturer)
-                        .modelYear(this.modelYear)
-                        .name(this.name)
-                        .build();
-        }
-
         public Vehicle toVehicleEntity(Company company, VehicleModel vehicleModel) {
                 return Vehicle.builder()
                         .vehicleModel(vehicleModel)

--- a/src/main/java/org/thisway/vehicle/repository/VehicleModelRepository.java
+++ b/src/main/java/org/thisway/vehicle/repository/VehicleModelRepository.java
@@ -1,5 +1,6 @@
 package org.thisway.vehicle.repository;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +10,7 @@ public interface VehicleModelRepository extends JpaRepository<VehicleModel, Long
   boolean existsByManufacturerAndNameAndModelYear(String manufacturer, String name, Integer year);
 
   Page<VehicleModel> findAllByActiveTrue(Pageable pageable);
+
+  Optional<VehicleModel> findByIdAndActiveTrue(Long id);
 
 }

--- a/src/main/java/org/thisway/vehicle/service/VehicleService.java
+++ b/src/main/java/org/thisway/vehicle/service/VehicleService.java
@@ -44,6 +44,7 @@ public class VehicleService {
         Member member = getCurrentMember();
         Company company = validateMemberCompanyAndPermission(member);
         VehicleModel vehicleModel = findActiveVehicleModel(request.vehicleModelId());
+        isCarNumberDuplicate(request.carNumber());
         Vehicle vehicle = request.toVehicleEntity(company, vehicleModel);
         vehicleRepository.save(vehicle);
     }
@@ -155,6 +156,12 @@ public class VehicleService {
         Company vehicleCompany = vehicle.getCompany();
         if (vehicleCompany == null || !vehicleCompany.getId().equals(memberCompany.getId())) {
             throw new CustomException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+    }
+
+    private void isCarNumberDuplicate(String carNumber) {
+        if (vehicleRepository.existsByCarNumberAndActiveTrue(carNumber)) {
+            throw new CustomException(ErrorCode.VEHICLE_DUPLICATE_CAR_NUMBER);
         }
     }
 }

--- a/src/main/java/org/thisway/vehicle/validation/VehicleUpdateValidator.java
+++ b/src/main/java/org/thisway/vehicle/validation/VehicleUpdateValidator.java
@@ -41,3 +41,4 @@ public class VehicleUpdateValidator {
                 request.model() == null;
     }
 }
+

--- a/src/test/java/org/thisway/vehicle/CarNumberValidationTest.java
+++ b/src/test/java/org/thisway/vehicle/CarNumberValidationTest.java
@@ -1,18 +1,19 @@
 package org.thisway.vehicle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.thisway.vehicle.dto.request.VehicleCreateRequest;
-import java.util.Set;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CarNumberValidationTest {
 
@@ -29,7 +30,7 @@ public class CarNumberValidationTest {
     void 차량번호검증_통과(){
         //given
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대", 2022, "아반떼", "12가3456", "흰색");
+                1L, "12가3456", "흰색");
 
         // when
         Set<ConstraintViolation<VehicleCreateRequest>> violations = validator.validate(request);
@@ -49,7 +50,7 @@ public class CarNumberValidationTest {
     void 다양한_유효한_차량번호_검증(String carNumber) {
         // given
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대", 2022, "아반떼", carNumber, "흰색");
+                1L, carNumber, "흰색");
 
         // when
         Set<ConstraintViolation<VehicleCreateRequest>> violations = validator.validate(request);
@@ -73,7 +74,7 @@ public class CarNumberValidationTest {
     void 잘못된_차량번호_검증(String carNumber) {
         // given
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대", 2022, "아반떼", carNumber, "흰색");
+                1L, carNumber, "흰색");
 
         // when
         Set<ConstraintViolation<VehicleCreateRequest>> violations = validator.validate(request);

--- a/src/test/java/org/thisway/vehicle/controller/VehicleControllerTest.java
+++ b/src/test/java/org/thisway/vehicle/controller/VehicleControllerTest.java
@@ -65,7 +65,7 @@ class VehicleControllerTest {
     @WithMockUser(roles = { "COMPANY_ADMIN" })
     void 차량_등록_요청_성공() throws Exception {
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대", 2022, "아반떼", "12가3456", "흰색");
+                1L, "12가3456", "흰색");
         doNothing().when(vehicleService).registerVehicle(request);
 
         mockMvc.perform(
@@ -81,7 +81,7 @@ class VehicleControllerTest {
     @WithMockUser(roles = { "COMPANY_ADMIN" })
     void 차량_등록_요청_실패() throws Exception {
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대", 2022, "아반떼", "12가3456", "흰색");
+                1L, "12가3456", "흰색");
         doThrow(new CustomException(ErrorCode.COMPANY_NOT_FOUND))
                 .when(vehicleService).registerVehicle(request);
 

--- a/src/test/java/org/thisway/vehicle/service/VehicleServiceTest.java
+++ b/src/test/java/org/thisway/vehicle/service/VehicleServiceTest.java
@@ -33,7 +33,6 @@ import org.thisway.company.entity.Company;
 import org.thisway.company.repository.CompanyRepository;
 import org.thisway.member.entity.Member;
 import org.thisway.member.entity.MemberRole;
-import org.thisway.member.repository.MemberRepository;
 import org.thisway.security.service.SecurityService;
 import org.thisway.vehicle.dto.request.VehicleCreateRequest;
 import org.thisway.vehicle.dto.request.VehicleUpdateRequest;
@@ -100,7 +99,7 @@ class VehicleServiceTest {
         VehicleModel existingVehicleModel = VehicleModel.builder()
                 .manufacturer("현대")
                 .modelYear(2023)
-                .model("아반떼")
+                .name("아반떼")
                 .build();
 
         mockSecurityContext(mockMember);

--- a/src/test/java/org/thisway/vehicle/service/VehicleServiceTest.java
+++ b/src/test/java/org/thisway/vehicle/service/VehicleServiceTest.java
@@ -61,9 +61,6 @@ class VehicleServiceTest {
     private VehicleUpdateValidator vehicleUpdateValidator;
 
     @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
     private SecurityService securityService;
 
     @InjectMocks
@@ -82,10 +79,9 @@ class VehicleServiceTest {
     @DisplayName("차량 등록이 성공하는 경우")
     void 차량_등록_성공() {
         // given
+        Long vehicleModelId = 1L;
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대",
-                2023,
-                "아반떼",
+                vehicleModelId,
                 "12가3456",
                 "검정"
         );
@@ -95,46 +91,45 @@ class VehicleServiceTest {
         when(mockCompany.isActive()).thenReturn(true);
 
         MemberRole mockRole = mock(MemberRole.class);
-        Set<MemberRole> roles = new HashSet<>();
-        roles.add(MemberRole.COMPANY_ADMIN);
-        when(mockRole.getLowerOrEqualRoles()).thenReturn(roles);
+        when(mockRole.getLevel()).thenReturn(MemberRole.COMPANY_ADMIN.getLevel());
 
         Member mockMember = mock(Member.class);
         when(mockMember.getCompany()).thenReturn(mockCompany);
         when(mockMember.getRole()).thenReturn(mockRole);
 
+        VehicleModel existingVehicleModel = VehicleModel.builder()
+                .manufacturer("현대")
+                .modelYear(2023)
+                .model("아반떼")
+                .build();
+
         mockSecurityContext(mockMember);
 
         when(companyRepository.findById(1L)).thenReturn(Optional.of(mockCompany));
-        when(vehicleModelRepository.save(any(VehicleModel.class))).thenReturn(mock(VehicleModel.class));
+        when(vehicleModelRepository.findByIdAndActiveTrue(vehicleModelId)).thenReturn(Optional.of(existingVehicleModel));
 
         // when
         vehicleService.registerVehicle(request);
 
         // then
-        verify(vehicleModelRepository).save(vehicleModelCaptor.capture());
+        verify(vehicleModelRepository).findByIdAndActiveTrue(vehicleModelId);
         verify(companyRepository).findById(1L);
         verify(vehicleRepository).save(vehicleCaptor.capture());
 
-        VehicleModel capturedDetail = vehicleModelCaptor.getValue();
         Vehicle capturedVehicle = vehicleCaptor.getValue();
-
-        assertEquals("현대", capturedDetail.getManufacturer());
-        assertEquals("아반떼", capturedDetail.getName());
-        assertEquals(2023, capturedDetail.getModelYear());
 
         assertEquals("12가3456", capturedVehicle.getCarNumber());
         assertEquals("검정", capturedVehicle.getColor());
+        assertEquals(existingVehicleModel, capturedVehicle.getVehicleModel());
     }
 
     @Test
     @DisplayName("차량 등록시 회사를 찾을 수 없는 경우 차량 등록 불가")
     void 차량_등록_실패_회사를_찾을수없음() {
         // given
+        Long vehicleModelId = 1L;
         VehicleCreateRequest request = new VehicleCreateRequest(
-                "현대",
-                2023,
-                "아반떼",
+                vehicleModelId,
                 "12가3456",
                 "검정"
         );
@@ -143,9 +138,7 @@ class VehicleServiceTest {
         when(mockCompany.getId()).thenReturn(1L);
 
         MemberRole mockRole = mock(MemberRole.class);
-        Set<MemberRole> roles = new HashSet<>();
-        roles.add(MemberRole.COMPANY_ADMIN);
-        when(mockRole.getLowerOrEqualRoles()).thenReturn(roles);
+        when(mockRole.getLevel()).thenReturn(MemberRole.COMPANY_ADMIN.getLevel());
 
         Member mockMember = mock(Member.class);
         when(mockMember.getCompany()).thenReturn(mockCompany);
@@ -160,10 +153,48 @@ class VehicleServiceTest {
                 () -> vehicleService.registerVehicle(request));
 
         verify(companyRepository).findById(1L);
-        verify(vehicleModelRepository, never()).save(any(VehicleModel.class));
+        verify(vehicleModelRepository, never()).findByIdAndActiveTrue(any());
         verify(vehicleRepository, never()).save(any(Vehicle.class));
 
         assertEquals(ErrorCode.COMPANY_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("차량 등록시 차량 모델을 찾을 수 없는 경우 차량 등록 불가")
+    void 차량_등록_실패_차량모델을_찾을수없음() {
+        // given
+        Long vehicleModelId = 1L;
+        VehicleCreateRequest request = new VehicleCreateRequest(
+                vehicleModelId,
+                "12가3456",
+                "검정"
+        );
+
+        Company mockCompany = mock(Company.class);
+        when(mockCompany.getId()).thenReturn(1L);
+        when(mockCompany.isActive()).thenReturn(true);
+
+        MemberRole mockRole = mock(MemberRole.class);
+        when(mockRole.getLevel()).thenReturn(MemberRole.COMPANY_ADMIN.getLevel());
+
+        Member mockMember = mock(Member.class);
+        when(mockMember.getCompany()).thenReturn(mockCompany);
+        when(mockMember.getRole()).thenReturn(mockRole);
+
+        mockSecurityContext(mockMember);
+
+        when(companyRepository.findById(1L)).thenReturn(Optional.of(mockCompany));
+        when(vehicleModelRepository.findByIdAndActiveTrue(vehicleModelId)).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> vehicleService.registerVehicle(request));
+
+        verify(companyRepository).findById(1L);
+        verify(vehicleModelRepository).findByIdAndActiveTrue(vehicleModelId);
+        verify(vehicleRepository, never()).save(any(Vehicle.class));
+
+        assertEquals(ErrorCode.VEHICLE_MODEL_NOT_FOUND, exception.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
#128 
### ✨ 반영 브랜치
refactor/128 -> develop
### 📝 변경 사항
- [x] Vehicle 등록 형식 변경
[기존] VehicleModel의 필드명을 각각 입력받아 등록
[변경] VehicleModel을 따로 등록 후 VehicleModel의 Id를 전달받아서 등록
- [x] 차량 번호 중복 체크 로직 추가
### ➕ 추가 메모

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
[차량 번호 중복 입력 시]
<img width="422" alt="image" src="https://github.com/user-attachments/assets/be380831-a645-4fd5-8f5b-856fad587e7b" />

