### PR TITLE
대시보드에 필요한 수치 정보 조회 API 생성

### DIFF
--- a/src/main/java/org/thisway/security/config/policy/vehicle/VehicleAuthorizationPolicy.java
+++ b/src/main/java/org/thisway/security/config/policy/vehicle/VehicleAuthorizationPolicy.java
@@ -28,12 +28,13 @@ public class VehicleAuthorizationPolicy {
                         List.of("/api/vehicles/{id}"),
                         "COMPANY_ADMIN", "COMPANY_CHEF"),
 
-                // 조회 (전체/상세): MEMBER, COMPANY_ADMIN, COMPANY_CHEF
+                // 조회 (전체/상세/대시보드): MEMBER, COMPANY_ADMIN, COMPANY_CHEF
                 withRoles(
                         HttpMethod.GET,
                         List.of(
                                 "/api/vehicles",
-                                "/api/vehicles/{id}"),
+                                "/api/vehicles/{id}",
+                                "/api/vehicles/dashboard"),
                         "MEMBER", "COMPANY_ADMIN", "COMPANY_CHEF"));
     }
 }

--- a/src/main/java/org/thisway/vehicle/controller/VehicleController.java
+++ b/src/main/java/org/thisway/vehicle/controller/VehicleController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.thisway.vehicle.dto.request.VehicleCreateRequest;
 import org.thisway.vehicle.dto.request.VehicleUpdateRequest;
+import org.thisway.vehicle.dto.response.VehicleDashboardResponse;
 import org.thisway.vehicle.dto.response.VehicleResponse;
 import org.thisway.vehicle.dto.response.VehiclesResponse;
 import org.thisway.vehicle.service.VehicleService;
@@ -60,5 +61,11 @@ public class VehicleController {
         vehicleService.updateVehicle(id, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<VehicleDashboardResponse> getVehicleDashboard() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(vehicleService.getVehicleDashboard());
     }
 }

--- a/src/main/java/org/thisway/vehicle/dto/response/VehicleDashboardResponse.java
+++ b/src/main/java/org/thisway/vehicle/dto/response/VehicleDashboardResponse.java
@@ -1,0 +1,8 @@
+package org.thisway.vehicle.dto.response;
+
+public record VehicleDashboardResponse(
+        long totalVehicles,
+        long powerOnVehicles,
+        long powerOffVehicles
+) {
+}

--- a/src/main/java/org/thisway/vehicle/repository/VehicleRepository.java
+++ b/src/main/java/org/thisway/vehicle/repository/VehicleRepository.java
@@ -15,4 +15,8 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
     boolean existsByCarNumberAndActiveTrue(String carNumber);
 
     Page<Vehicle> findAllByCompanyAndActiveTrue(Company company, Pageable pageable);
+
+    long countByCompanyIdAndActiveTrue(long companyId);
+
+    long countByCompanyIdAndPowerOnIsAndActiveTrue(long companyId, boolean powerOn);
 }

--- a/src/main/java/org/thisway/vehicle/service/VehicleService.java
+++ b/src/main/java/org/thisway/vehicle/service/VehicleService.java
@@ -15,6 +15,7 @@ import org.thisway.member.entity.MemberRole;
 import org.thisway.security.service.SecurityService;
 import org.thisway.vehicle.dto.request.VehicleCreateRequest;
 import org.thisway.vehicle.dto.request.VehicleUpdateRequest;
+import org.thisway.vehicle.dto.response.VehicleDashboardResponse;
 import org.thisway.vehicle.dto.response.VehicleResponse;
 import org.thisway.vehicle.dto.response.VehiclesResponse;
 import org.thisway.vehicle.entity.Vehicle;
@@ -77,12 +78,26 @@ public class VehicleService {
         vehicle.update(request);
     }
 
+    @Transactional(readOnly = true)
+    public VehicleDashboardResponse getVehicleDashboard() {
+        long companyId = securityService.getCurrentMemberDetails().getCompanyId();
+        long totalVehicles = vehicleRepository.countByCompanyIdAndActiveTrue(companyId);
+        long powerOnVehicles = vehicleRepository.countByCompanyIdAndPowerOnIsAndActiveTrue(companyId, true);
+        long powerOffVehicles = vehicleRepository.countByCompanyIdAndPowerOnIsAndActiveTrue(companyId, false);
+
+        return new VehicleDashboardResponse(
+                totalVehicles,
+                powerOnVehicles,
+                powerOffVehicles
+        );
+    }
+
     private Vehicle findActiveVehicle(Long id) {
         return vehicleRepository.findByIdAndActiveTrue(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.VEHICLE_NOT_FOUND));
     }
 
-    private VehicleModel findActiveVehicleModel(Long id){
+    private VehicleModel findActiveVehicleModel(Long id) {
         return vehicleModelRepository.findByIdAndActiveTrue(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.VEHICLE_MODEL_NOT_FOUND));
     }

--- a/src/test/java/org/thisway/vehicle/controller/VehicleControllerTest.java
+++ b/src/test/java/org/thisway/vehicle/controller/VehicleControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -36,6 +37,7 @@ import org.thisway.common.CustomException;
 import org.thisway.common.ErrorCode;
 import org.thisway.vehicle.dto.request.VehicleCreateRequest;
 import org.thisway.vehicle.dto.request.VehicleUpdateRequest;
+import org.thisway.vehicle.dto.response.VehicleDashboardResponse;
 import org.thisway.vehicle.dto.response.VehicleResponse;
 import org.thisway.vehicle.dto.response.VehiclesResponse;
 import org.thisway.vehicle.service.VehicleService;
@@ -62,23 +64,23 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 등록 요청 성공")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_등록_요청_성공() throws Exception {
         VehicleCreateRequest request = new VehicleCreateRequest(
                 1L, "12가3456", "흰색");
         doNothing().when(vehicleService).registerVehicle(request);
 
         mockMvc.perform(
-                post("/api/vehicles")
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(request)))
+                        post("/api/vehicles")
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isCreated());
     }
 
     @Test
     @DisplayName("차량 등록 요청 실패 - 업체 미존재")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_등록_요청_실패() throws Exception {
         VehicleCreateRequest request = new VehicleCreateRequest(
                 1L, "12가3456", "흰색");
@@ -86,9 +88,9 @@ class VehicleControllerTest {
                 .when(vehicleService).registerVehicle(request);
 
         mockMvc.perform(
-                post("/api/vehicles")
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(request)))
+                        post("/api/vehicles")
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(ErrorCode.COMPANY_NOT_FOUND.getCode()));
@@ -96,7 +98,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 상세 조회 API 성공")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_상세_조회_성공() throws Exception {
         // given
         Long vehicleId = 1L;
@@ -114,8 +116,8 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                get("/api/vehicles/{id}", vehicleId)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get("/api/vehicles/{id}", vehicleId)
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
@@ -134,7 +136,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 상세 조회 API 실패 - 차량 없음")
-    @WithMockUser(roles = { "MEMBER" })
+    @WithMockUser(roles = {"MEMBER"})
     void 차량_상세_조회_실패() throws Exception {
         // given
         Long vehicleId = 1L;
@@ -143,8 +145,8 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                get("/api/vehicles/{id}", vehicleId)
-                        .contentType(MediaType.APPLICATION_JSON))
+                        get("/api/vehicles/{id}", vehicleId)
+                                .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -157,25 +159,25 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 삭제 요청 성공")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_삭제_요청_성공() throws Exception {
         doNothing().when(vehicleService).deleteVehicle(1L);
 
         mockMvc.perform(
-                delete("/api/vehicles/1"))
+                        delete("/api/vehicles/1"))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("차량 삭제 요청 실패 - 차량 미존재")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_삭제_요청_실패() throws Exception {
         doThrow(new CustomException(ErrorCode.VEHICLE_NOT_FOUND))
                 .when(vehicleService).deleteVehicle(1L);
 
         MvcResult mvcResult = mockMvc.perform(
-                delete("/api/vehicles/1"))
+                        delete("/api/vehicles/1"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -188,7 +190,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 삭제 요청 실패 - 이미 삭제된 차량")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 이미_삭제된_차량_삭제_요청_실패() throws Exception {
         // given
         doThrow(new CustomException(ErrorCode.VEHICLE_ALREADY_DELETED))
@@ -196,7 +198,7 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                delete("/api/vehicles/1"))
+                        delete("/api/vehicles/1"))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -209,7 +211,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 목록 조회 성공 - 기본 페이지네이션")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_목록_조회_성공_기본_페이지네이션() throws Exception {
         // given
         List<VehicleResponse> vehicles = List.of(
@@ -222,7 +224,7 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                get("/api/vehicles"))
+                        get("/api/vehicles"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
@@ -240,7 +242,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 목록 조회 성공 - 두 번째 페이지")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_목록_조회_성공_두번째_페이지() throws Exception {
         // given
         List<VehicleResponse> vehicles = List.of(
@@ -252,9 +254,9 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                get("/api/vehicles")
-                        .param("page", "3")
-                        .param("size", "2"))
+                        get("/api/vehicles")
+                                .param("page", "3")
+                                .param("size", "2"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
@@ -272,7 +274,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 목록 조회 성공 - 정렬 적용")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_목록_조회_성공_정렬_적용() throws Exception {
         // given
         List<VehicleResponse> descendingOrder = List.of(
@@ -287,8 +289,8 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                get("/api/vehicles")
-                        .param("sort", "carNumber,desc"))
+                        get("/api/vehicles")
+                                .param("sort", "carNumber,desc"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
@@ -304,7 +306,7 @@ class VehicleControllerTest {
 
     @Test
     @DisplayName("차량 정보 수정 요청 성공")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_정보_수정_요청_성공() throws Exception {
         // given
         Long vehicleId = 1L;
@@ -318,16 +320,16 @@ class VehicleControllerTest {
 
         // when & then
         mockMvc.perform(
-                patch("/api/vehicles/{id}", vehicleId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        patch("/api/vehicles/{id}", vehicleId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("차량 정보 수정 요청 실패 - 차량을 찾을 수 없음")
-    @WithMockUser(roles = { "COMPANY_ADMIN" })
+    @WithMockUser(roles = {"COMPANY_ADMIN"})
     void 차량_정보_수정_요청_실패_차량_미존재() throws Exception {
         // given
         Long vehicleId = 999L;
@@ -342,9 +344,9 @@ class VehicleControllerTest {
 
         // when & then
         MvcResult mvcResult = mockMvc.perform(
-                patch("/api/vehicles/{id}", vehicleId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        patch("/api/vehicles/{id}", vehicleId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andReturn();
@@ -353,5 +355,35 @@ class VehicleControllerTest {
         ApiErrorResponse response = objectMapper.readValue(
                 responseBody, ApiErrorResponse.class);
         assertThat(response.message()).isEqualTo(ErrorCode.VEHICLE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("차량 대시보드 요청 성공")
+    @WithMockUser(roles = {"COMPANY_CHEF"})
+    void 차량_대시보드_요청_성공() throws Exception {
+        // given
+        VehicleDashboardResponse vehicleDashboard = new VehicleDashboardResponse(3, 2, 1);
+        when(vehicleService.getVehicleDashboard())
+                .thenReturn(vehicleDashboard);
+
+        // when
+        String responseBody = mockMvc.perform(
+                        get("/api/vehicles/dashboard")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // then
+        VehicleDashboardResponse response = objectMapper.readValue(
+                responseBody,
+                VehicleDashboardResponse.class
+        );
+
+        assertThat(response.totalVehicles()).isEqualTo(vehicleDashboard.totalVehicles());
+        assertThat(response.powerOnVehicles()).isEqualTo(vehicleDashboard.powerOnVehicles());
+        assertThat(response.powerOffVehicles()).isEqualTo(vehicleDashboard.powerOffVehicles());
     }
 }


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈

### ✨ 반영 브랜치
- feat/147 -> develop

### 📝 변경 사항
- 대시보드에 필요한 수치 정보 조회 API 생성
  다음 화면을 위한 API입니다.
  ![Image](https://github.com/user-attachments/assets/d8f99e35-d298-4126-9196-7368c92026ae)

### ➕ 추가 메모

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)

