### PR TITLE
운행 일지 테이블 분리 및 시동 위치 통계 조회 API 개발

### DIFF
--- a/src/main/java/org/thisway/common/ErrorCode.java
+++ b/src/main/java/org/thisway/common/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
 
     // 운행 로그 x7xxx
     TRIP_LOG_NOT_FOUND("17000", "해당하는 로그가 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
+    TRIP_LOG_ADDRESS_NOT_FOUND("17001", "주소를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST)
     ;
 
     private final String code;

--- a/src/main/java/org/thisway/log/repository/LogRepository.java
+++ b/src/main/java/org/thisway/log/repository/LogRepository.java
@@ -3,6 +3,7 @@ package org.thisway.log.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import org.thisway.log.domain.GeofenceLogData;
@@ -15,6 +16,7 @@ import org.thisway.log.domain.PowerLogData;
 public class LogRepository {
 
     private final JdbcTemplate jdbcTemplate;
+    private final ReactiveStringRedisTemplate reactiveStringRedisTemplate;
 
     public void savePowerLog(PowerLogData powerLogData) {
         Object[] powerLogParams = new Object[]{
@@ -141,6 +143,27 @@ public class LogRepository {
                         rs.getDouble("longitude"),
                         rs.getInt("total_trip_meter")
                 )
+        );
+    }
+
+    public PowerLogData findOnLogByVehicleIdAndPowerTime(Long vehicleId, LocalDateTime powerTime) {
+        String sql = "SELECT vehicle_id, mdn, power_status, power_time, gps_status, latitude, longitude, total_trip_meter "
+                + "FROM power_log "
+                + "WHERE vehicle_id = ? AND power_time = ?";
+
+        Object[] params = new Object[]{ vehicleId, powerTime };
+
+        return jdbcTemplate.queryForObject(sql,
+                (rs, rowNum) -> new PowerLogData(
+                        rs.getLong("vehicle_id"),
+                        rs.getString("mdn"),
+                        rs.getBoolean("power_status"),
+                        rs.getTimestamp("power_time").toLocalDateTime(),
+                        GpsStatus.fromCode(rs.getString("gps_status")),
+                        rs.getDouble("latitude"),
+                        rs.getDouble("longitude"),
+                        rs.getInt("total_trip_meter")
+                ), params
         );
     }
 

--- a/src/main/java/org/thisway/log/repository/LogRepository.java
+++ b/src/main/java/org/thisway/log/repository/LogRepository.java
@@ -16,7 +16,6 @@ import org.thisway.log.domain.PowerLogData;
 public class LogRepository {
 
     private final JdbcTemplate jdbcTemplate;
-    private final ReactiveStringRedisTemplate reactiveStringRedisTemplate;
 
     public void savePowerLog(PowerLogData powerLogData) {
         Object[] powerLogParams = new Object[]{

--- a/src/main/java/org/thisway/log/service/LogService.java
+++ b/src/main/java/org/thisway/log/service/LogService.java
@@ -20,6 +20,7 @@ import org.thisway.log.dto.request.gpsLog.GpsLogEntry;
 import org.thisway.log.dto.request.gpsLog.GpsLogRequest;
 import org.thisway.log.dto.request.powerLog.PowerLogRequest;
 import org.thisway.log.repository.LogRepository;
+import org.thisway.triplog.service.TripLogService;
 import org.thisway.vehicle.repository.VehicleRepository;
 
 @Slf4j
@@ -32,6 +33,8 @@ public class LogService {
     private final EmulatorRepository emulatorRepository;
     private final LogRepository logRepository;
     private final LogDataConverter converter;
+
+    private final TripLogService tripLogService;
 
     public void savePowerLog(PowerLogRequest request) {
         log.info("시동 정보 로그 수신: MDN={}, onTime={}, offTime={}",
@@ -71,6 +74,13 @@ public class LogService {
             });
             log.info("시동 OFF 정보 로그 저장: MDN={}, offTime={}, totalTripMeter={}",
                     request.mdn(), request.offTime(), request.sum());
+
+            tripLogService.saveTripLog(
+                    logRepository.findOnLogByVehicleIdAndPowerTime(vehicleId, converter.convertDateTimeWithSec(request.onTime())),
+                    powerLogData
+            );
+            log.info("운행 기록 저장 : MDN={}, onTime={}, offTime={}",
+                    request.mdn(), request.onTime(), request.offTime());
         }
 
         log.info("시동 정보 로그 저장 완료: MDN={}", request.mdn());

--- a/src/main/java/org/thisway/security/config/policy/RequestAuthorizationPolicy.java
+++ b/src/main/java/org/thisway/security/config/policy/RequestAuthorizationPolicy.java
@@ -8,6 +8,7 @@ import org.thisway.security.config.policy.auth.AuthAuthorizationPolicy;
 import org.thisway.security.config.policy.company.CompanyAuthorizationPolicy;
 import org.thisway.security.config.policy.emulator.EmulatorAuthorizationPolicy;
 import org.thisway.security.config.policy.member.MemberAuthorizationPolicy;
+import org.thisway.security.config.policy.statistics.StatisticsAuthorizationPolicy;
 import org.thisway.security.config.policy.triplog.TripLogAuthorizationPolicy;
 import org.thisway.security.config.policy.vehicle.VehicleAuthorizationPolicy;
 
@@ -25,6 +26,7 @@ public class RequestAuthorizationPolicy {
         rules.addAll(EmulatorAuthorizationPolicy.getRules());
         rules.addAll(ActuatorAuthorizationPolicy.getRules());
         rules.addAll(TripLogAuthorizationPolicy.getRules());
+        rules.addAll(StatisticsAuthorizationPolicy.getRules());
 
         return rules;
     }

--- a/src/main/java/org/thisway/security/config/policy/statistics/StatisticsAuthorizationPolicy.java
+++ b/src/main/java/org/thisway/security/config/policy/statistics/StatisticsAuthorizationPolicy.java
@@ -1,0 +1,22 @@
+package org.thisway.security.config.policy.statistics;
+
+import org.springframework.http.HttpMethod;
+import org.thisway.security.config.policy.AuthorizationRule;
+
+import java.util.List;
+
+import static org.thisway.security.config.policy.EndpointRule.withRoles;
+
+public class StatisticsAuthorizationPolicy {
+    public static List<AuthorizationRule> getRules() {
+        return List.of(
+                // 통계 관련 API
+                withRoles(
+                        HttpMethod.GET,
+                        List.of("/api/statistics/**"),
+                        "COMPANY_ADMIN", "COMPANY_CHEF"
+                )
+
+        );
+    }
+}

--- a/src/main/java/org/thisway/triplog/controller/StatisticController.java
+++ b/src/main/java/org/thisway/triplog/controller/StatisticController.java
@@ -1,0 +1,40 @@
+package org.thisway.triplog.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.thisway.security.dto.request.MemberDetails;
+import org.thisway.triplog.dto.response.TripLocationStats;
+import org.thisway.triplog.service.StatisticService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/statistics")
+public class StatisticController {
+
+    private final StatisticService statisticService;
+
+    @GetMapping("/start-location")
+    public ResponseEntity<List<TripLocationStats>> getStartLocationStatBetweenDates(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        LocalDateTime startTime = LocalDateTime.of(startDate, LocalTime.MIN);
+        LocalDateTime endTime = LocalDateTime.of(endDate, LocalTime.MAX);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(statisticService.getStartLocationStatBetweenDates(memberDetails.getCompanyId(), startTime, endTime));
+    }
+}

--- a/src/main/java/org/thisway/triplog/converter/ReverseGeocodingConverter.java
+++ b/src/main/java/org/thisway/triplog/converter/ReverseGeocodingConverter.java
@@ -1,0 +1,69 @@
+package org.thisway.triplog.converter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.thisway.common.CustomException;
+import org.thisway.common.ErrorCode;
+import org.thisway.triplog.dto.KakaoCoordToAddress;
+import org.thisway.triplog.dto.ReverseGeocodeResult;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class ReverseGeocodingConverter {
+
+    @Value("${kakao.rest-api-key}")
+    private String kakaoApiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public ReverseGeocodeResult convertToAddress(double latitude, double longitude) {
+        String url = String.format(
+                "https://dapi.kakao.com/v2/local/geo/coord2address.json?x=%f&y=%f"
+                , longitude, latitude
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoCoordToAddress> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                entity,
+                KakaoCoordToAddress.class
+        );
+
+        List<KakaoCoordToAddress.Document> addresses = Objects.requireNonNull(response.getBody()).documents();
+
+        if (addresses == null || addresses.isEmpty()) {
+            throw new CustomException(ErrorCode.TRIP_LOG_ADDRESS_NOT_FOUND);
+        }
+
+        KakaoCoordToAddress.Address address = addresses.getFirst().address();
+
+        String fullAddress = address.address_name();
+        String addr = String.format(
+                "%s %s %s",
+                address.region_1depth_name(),
+                address.region_2depth_name(),
+                address.region_3depth_name()
+        );
+
+        String addrDetail = fullAddress.replace(addr, "").trim();
+
+        return new ReverseGeocodeResult(
+                addr,
+                addrDetail
+        );
+    }
+
+}

--- a/src/main/java/org/thisway/triplog/dto/KakaoCoordToAddress.java
+++ b/src/main/java/org/thisway/triplog/dto/KakaoCoordToAddress.java
@@ -1,0 +1,18 @@
+package org.thisway.triplog.dto;
+
+import java.util.List;
+
+public record KakaoCoordToAddress(
+        List<Document> documents
+) {
+    public record Document(
+            Address address
+    ) {}
+
+    public record Address(
+            String address_name,
+            String region_1depth_name,
+            String region_2depth_name,
+            String region_3depth_name
+    ) {}
+}

--- a/src/main/java/org/thisway/triplog/dto/ReverseGeocodeResult.java
+++ b/src/main/java/org/thisway/triplog/dto/ReverseGeocodeResult.java
@@ -1,0 +1,8 @@
+package org.thisway.triplog.dto;
+
+public record ReverseGeocodeResult (
+        String addr,
+        String addrDetail
+) {
+
+}

--- a/src/main/java/org/thisway/triplog/dto/response/TripLocationStats.java
+++ b/src/main/java/org/thisway/triplog/dto/response/TripLocationStats.java
@@ -1,0 +1,7 @@
+package org.thisway.triplog.dto.response;
+
+public record TripLocationStats(
+        String addr,
+        Long count
+) {
+}

--- a/src/main/java/org/thisway/triplog/entity/TripLog.java
+++ b/src/main/java/org/thisway/triplog/entity/TripLog.java
@@ -1,0 +1,84 @@
+package org.thisway.triplog.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.thisway.common.BaseEntity;
+import org.thisway.vehicle.entity.Vehicle;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TripLog extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "vehicle_id", nullable = false)
+    private Vehicle vehicle;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    private LocalDateTime endTime;
+
+    @Column(nullable = false)
+    private Integer totalTripMeter;
+
+    @Column(nullable = false)
+    private Double onLatitude;
+
+    @Column(nullable = false)
+    private Double onLongitude;
+
+    @Column(nullable = false)
+    private String onAddr;
+
+    @Column
+    private String onAddrDetail;
+
+    @Column(nullable = false)
+    private Double offLatitude;
+
+    @Column(nullable = false)
+    private Double offLongitude;
+
+    @Column(nullable = false)
+    private String offAddr;
+
+    @Column
+    private String offAddrDetail;
+
+    @Builder
+    public TripLog (
+            Vehicle vehicle,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            Integer totalTripMeter,
+            Double onLatitude,
+            Double onLongitude,
+            String onAddress,
+            String onAddrDetail,
+            Double offLatitude,
+            Double offLongitude,
+            String offAddress,
+            String offAddrDetail
+    ) {
+        this.vehicle = vehicle;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.totalTripMeter = totalTripMeter;
+        this.onLatitude = onLatitude;
+        this.onLongitude = onLongitude;
+        this.onAddr = onAddress;
+        this.onAddrDetail = onAddrDetail;
+        this.offLatitude = offLatitude;
+        this.offLongitude = offLongitude;
+        this.offAddr = offAddress;
+        this.offAddrDetail = offAddrDetail;
+    }
+
+}

--- a/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
+++ b/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
@@ -1,0 +1,8 @@
+package org.thisway.triplog.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.thisway.triplog.entity.TripLog;
+
+public interface TripLogRepository extends JpaRepository<TripLog, Long> {
+
+}

--- a/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
+++ b/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
@@ -1,8 +1,25 @@
 package org.thisway.triplog.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.thisway.triplog.dto.response.TripLocationStats;
 import org.thisway.triplog.entity.TripLog;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface TripLogRepository extends JpaRepository<TripLog, Long> {
 
+    @Query("SELECT new org.thisway.triplog.dto.response.TripLocationStats(t.onAddr, COUNT(t)) " +
+            "FROM TripLog t " +
+            "WHERE t.vehicle.company.id = :companyId " +
+            "AND t.startTime >= :from AND t.startTime <= :to " +
+            "GROUP BY t.onAddr"
+    )
+    List<TripLocationStats> countGroupedByOnAddr(
+            @Param("companyId")Long companyId,
+            @Param("from")LocalDateTime from,
+            @Param("to")LocalDateTime to
+    );
 }

--- a/src/main/java/org/thisway/triplog/service/StatisticService.java
+++ b/src/main/java/org/thisway/triplog/service/StatisticService.java
@@ -1,0 +1,22 @@
+package org.thisway.triplog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thisway.security.service.SecurityService;
+import org.thisway.triplog.dto.response.TripLocationStats;
+import org.thisway.triplog.repository.TripLogRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticService {
+    private final TripLogRepository tripLogRepository;
+
+    public List<TripLocationStats> getStartLocationStatBetweenDates(Long companyId, LocalDateTime startTime, LocalDateTime endTime) {
+        return tripLogRepository.countGroupedByOnAddr(companyId, startTime, endTime);
+    }
+}

--- a/src/main/java/org/thisway/triplog/service/StatisticService.java
+++ b/src/main/java/org/thisway/triplog/service/StatisticService.java
@@ -3,7 +3,6 @@ package org.thisway.triplog.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thisway.security.service.SecurityService;
 import org.thisway.triplog.dto.response.TripLocationStats;
 import org.thisway.triplog.repository.TripLogRepository;
 

--- a/src/test/java/org/thisway/log/service/LogServiceTest.java
+++ b/src/test/java/org/thisway/log/service/LogServiceTest.java
@@ -30,6 +30,7 @@ import org.thisway.log.dto.request.gpsLog.GpsLogEntry;
 import org.thisway.log.dto.request.gpsLog.GpsLogRequest;
 import org.thisway.log.dto.request.powerLog.PowerLogRequest;
 import org.thisway.log.repository.LogRepository;
+import org.thisway.triplog.service.TripLogService;
 import org.thisway.vehicle.entity.Vehicle;
 import org.thisway.vehicle.repository.VehicleRepository;
 
@@ -53,6 +54,8 @@ public class LogServiceTest {
     private VehicleRepository vehicleRepository;
     @InjectMocks
     private LogService logService;
+    @Mock
+    private TripLogService tripLogService;
 
     private void setupMocks() {
         when(emulatorRepository.findByMdn(VALID_MDN)).thenReturn(Optional.of(emulator));

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -42,4 +42,7 @@ security:
     secret-key: szU3FELDRTw9sJzzP1cWuo/xUzIjSvMGGSWKlMCgku/vZwsSmi8BHsH/rnsAyTzTAQ2IGS0mgr/oxi4WsHMhcQ==
     access-token-validity-ms: 360000
 
+kakao:
+  rest-api-key: testkakaorestapikey
+
 gps-log-collect-mode: direct


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가

### 📌 관련 이슈
#158 

### ✨ 반영 브랜치
feat/158 -> develop

### 📝 변경 사항
- [x] 운행일지 테이블 분리
- [x] 시동 위치 통계 조회 API 개발

### ➕ 추가 메모
- 현재 TripLogService 내 logRepository로 tripLog 조회하는 것 수정 예정입니다... 패키지 더러워도 다음 PR에 수정될 예정이니 일단 skip 해주세요.
- 테스트 코드도 마찬가지로 운행일지 관련 API 로직 정리 후 추가 예정입니다.

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
<img width="996" alt="스크린샷 2025-06-19 14 50 56" src="https://github.com/user-attachments/assets/84dd8887-26fe-4cfe-8140-4fa4672b002f" />

![스크린샷 2025-06-19 14 52 22](https://github.com/user-attachments/assets/b95cb4c1-441e-4f4b-af57-59c68a1aa220)

