### PR TITLE
통계 API 병합 및 시동 위치 통계 백분율 추가

### DIFF
--- a/src/main/java/org/thisway/log/repository/LogRepository.java
+++ b/src/main/java/org/thisway/log/repository/LogRepository.java
@@ -311,7 +311,7 @@ public class LogRepository {
             SELECT EXTRACT(HOUR FROM gl.occurred_time) as hour, COUNT(*) as count
             FROM gps_log gl
             JOIN vehicle v ON gl.vehicle_id = v.id
-            WHERE v.company_id = ? 
+            WHERE v.company_id = ? AND total_trip_meter != 0
             AND gl.occurred_time >= ? 
             AND gl.occurred_time <= ?
             AND v.active = true

--- a/src/main/java/org/thisway/statistics/constant/StatisticConstants.java
+++ b/src/main/java/org/thisway/statistics/constant/StatisticConstants.java
@@ -15,7 +15,7 @@ public final class StatisticConstants {
     public static final double DEFAULT_OPERATION_RATE = 0.0;
     
     // 기본값 상수
-    public static final int DEFAULT_HOURLY_RATE = 0;
+    public static final double DEFAULT_HOURLY_RATE = 0;
     public static final int DEFAULT_PEAK_HOUR = 0;
     public static final int DEFAULT_LOW_HOUR = 0;
     

--- a/src/main/java/org/thisway/statistics/controller/StatisticController.java
+++ b/src/main/java/org/thisway/statistics/controller/StatisticController.java
@@ -1,9 +1,6 @@
 package org.thisway.statistics.controller;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -14,7 +11,6 @@ import org.springframework.web.bind.annotation.*;
 import org.thisway.security.dto.request.MemberDetails;
 import org.thisway.statistics.dto.response.StatisticResponse;
 import org.thisway.statistics.service.StatisticService;
-import org.thisway.triplog.dto.response.TripLocationStats;
 
 @Slf4j
 @RestController
@@ -24,25 +20,12 @@ public class StatisticController {
 
     private final StatisticService statisticService;
 
-    @GetMapping("/start-location")
-    public ResponseEntity<List<TripLocationStats>> getStartLocationStatBetweenDates(
-            @AuthenticationPrincipal MemberDetails memberDetails,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
-    ) {
-        LocalDateTime startTime = LocalDateTime.of(startDate, LocalTime.MIN);
-        LocalDateTime endTime = LocalDateTime.of(endDate, LocalTime.MAX);
-
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(statisticService.getStartLocationStatBetweenDates(memberDetails.getCompanyId(), startTime, endTime));
-    }
-
     /**
      * 날짜 범위 기반 통계 조회
      * @param memberDetails 인증된 사용자 정보
      * @param startDate 시작 날짜
      * @param endDate 종료 날짜
-     * @return 통계 응답 (시동 횟수, 평균 일일 시동 횟수, 총 운전 시간 등)
+     * @return 통계 응답 (시동 횟수, 평균 일일 시동 횟수, 총 운전 시간, 시동 위치 빈도 등)
      */
     @GetMapping
     public ResponseEntity<StatisticResponse> getStatistics(

--- a/src/main/java/org/thisway/statistics/dto/response/StatisticResponse.java
+++ b/src/main/java/org/thisway/statistics/dto/response/StatisticResponse.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.thisway.statistics.entity.Statistics;
 import org.thisway.statistics.constant.StatisticConstants;
+import org.thisway.triplog.dto.response.TripLocationStats;
 
 public record StatisticResponse(
     Long companyId,
@@ -17,11 +18,12 @@ public record StatisticResponse(
     Integer lowHour,
     Integer lowHourRate,
     Double averageOperationRate,
-    List<Integer> hours
+    List<Integer> hours,
+    List<TripLocationStats> locationStats
 ) {
   private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-  public static StatisticResponse from(Statistics statistics){
+  public static StatisticResponse from(Statistics statistics, List<TripLocationStats> locationStats) {
     // Statistics 엔티티의 getHourlyRatesArray() 메서드 활용
     List<Integer> hours = Arrays.asList(statistics.getHourlyRatesArray());
 
@@ -40,7 +42,8 @@ public record StatisticResponse(
         statistics.getLowHour(),
         lowHourRate,
         statistics.getAverageOperationRate(),
-        hours
+        hours,
+        locationStats
     );
   }
 
@@ -50,7 +53,7 @@ public record StatisticResponse(
   public static StatisticResponse fromAggregatedData(
       Long companyId, String dateRange, Integer powerOnCount, Double averageDailyPowerCount,
       Integer totalDrivingTime, Integer peakHour, Integer lowHour, Double averageOperationRate,
-      List<Integer> hourlyRates) {
+      List<Integer> hourlyRates, List<TripLocationStats> locationStats) {
 
     Integer peakHourRate = getSafeHourlyRate(peakHour, hourlyRates);
     Integer lowHourRate = getSafeHourlyRate(lowHour, hourlyRates);
@@ -66,7 +69,8 @@ public record StatisticResponse(
         lowHour,
         lowHourRate,
         averageOperationRate,
-        hourlyRates
+        hourlyRates,
+        locationStats
     );
   }
 

--- a/src/main/java/org/thisway/statistics/dto/response/StatisticResponse.java
+++ b/src/main/java/org/thisway/statistics/dto/response/StatisticResponse.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.thisway.statistics.entity.Statistics;
 import org.thisway.statistics.constant.StatisticConstants;
-import org.thisway.triplog.dto.response.TripLocationStats;
+import org.thisway.triplog.dto.TripLocationStats;
 
 public record StatisticResponse(
     Long companyId,

--- a/src/main/java/org/thisway/statistics/dto/response/StatisticResponse.java
+++ b/src/main/java/org/thisway/statistics/dto/response/StatisticResponse.java
@@ -14,22 +14,22 @@ public record StatisticResponse(
     Double averageDailyPowerCount,
     Integer totalDrivingTime,
     Integer peakHour,
-    Integer peakHourRate,
+    Double peakHourRate,
     Integer lowHour,
-    Integer lowHourRate,
+    Double lowHourRate,
     Double averageOperationRate,
-    List<Integer> hours,
+    List<Double> hours,
     List<TripLocationStats> locationStats
 ) {
   private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   public static StatisticResponse from(Statistics statistics, List<TripLocationStats> locationStats) {
     // Statistics 엔티티의 getHourlyRatesArray() 메서드 활용
-    List<Integer> hours = Arrays.asList(statistics.getHourlyRatesArray());
+    List<Double> hours = Arrays.asList(statistics.getHourlyRatesArray());
 
     // peakHour와 lowHour의 실제 퍼센트 값 계산
-    Integer peakHourRate = getSafeHourlyRate(statistics.getPeakHour(), hours);
-    Integer lowHourRate = getSafeHourlyRate(statistics.getLowHour(), hours);
+    Double peakHourRate = getSafeHourlyRate(statistics.getPeakHour(), hours);
+    Double lowHourRate = getSafeHourlyRate(statistics.getLowHour(), hours);
 
     return new StatisticResponse(
         statistics.getCompany().getId(),
@@ -53,10 +53,10 @@ public record StatisticResponse(
   public static StatisticResponse fromAggregatedData(
       Long companyId, String dateRange, Integer powerOnCount, Double averageDailyPowerCount,
       Integer totalDrivingTime, Integer peakHour, Integer lowHour, Double averageOperationRate,
-      List<Integer> hourlyRates, List<TripLocationStats> locationStats) {
+      List<Double> hourlyRates, List<TripLocationStats> locationStats) {
 
-    Integer peakHourRate = getSafeHourlyRate(peakHour, hourlyRates);
-    Integer lowHourRate = getSafeHourlyRate(lowHour, hourlyRates);
+    Double peakHourRate = getSafeHourlyRate(peakHour, hourlyRates);
+    Double lowHourRate = getSafeHourlyRate(lowHour, hourlyRates);
 
     return new StatisticResponse(
         companyId,
@@ -74,7 +74,7 @@ public record StatisticResponse(
     );
   }
 
-  private static Integer getSafeHourlyRate(Integer hour, List<Integer> hourlyRates) {
+  private static Double getSafeHourlyRate(Integer hour, List<Double> hourlyRates) {
     if (hour == null || hour < 0 || hour >= hourlyRates.size()) {
       return StatisticConstants.DEFAULT_HOURLY_RATE;
     }

--- a/src/main/java/org/thisway/statistics/entity/Statistics.java
+++ b/src/main/java/org/thisway/statistics/entity/Statistics.java
@@ -45,87 +45,87 @@ public class Statistics extends BaseEntity {
 
   // 시간대별 가동률
   @Column(nullable = false)
-  private Integer hour00;
+  private Double hour00;
 
   @Column(nullable = false)
-  private Integer hour01;
+  private Double hour01;
 
   @Column(nullable = false)
-  private Integer hour02;
+  private Double hour02;
 
   @Column(nullable = false)
-  private Integer hour03;
+  private Double hour03;
 
   @Column(nullable = false)
-  private Integer hour04;
+  private Double hour04;
 
   @Column(nullable = false)
-  private Integer hour05;
+  private Double hour05;
 
   @Column(nullable = false)
-  private Integer hour06;
+  private Double hour06;
 
   @Column(nullable = false)
-  private Integer hour07;
+  private Double hour07;
 
   @Column(nullable = false)
-  private Integer hour08;
+  private Double hour08;
 
   @Column(nullable = false)
-  private Integer hour09;
+  private Double hour09;
 
   @Column(nullable = false)
-  private Integer hour10;
+  private Double hour10;
 
   @Column(nullable = false)
-  private Integer hour11;
+  private Double hour11;
 
   @Column(nullable = false)
-  private Integer hour12;
+  private Double hour12;
 
   @Column(nullable = false)
-  private Integer hour13;
+  private Double hour13;
 
   @Column(nullable = false)
-  private Integer hour14;
+  private Double hour14;
 
   @Column(nullable = false)
-  private Integer hour15;
+  private Double hour15;
 
   @Column(nullable = false)
-  private Integer hour16;
+  private Double hour16;
 
   @Column(nullable = false)
-  private Integer hour17;
+  private Double hour17;
 
   @Column(nullable = false)
-  private Integer hour18;
+  private Double hour18;
 
   @Column(nullable = false)
-  private Integer hour19;
+  private Double hour19;
 
   @Column(nullable = false)
-  private Integer hour20;
+  private Double hour20;
 
   @Column(nullable = false)
-  private Integer hour21;
+  private Double hour21;
 
   @Column(nullable = false)
-  private Integer hour22;
+  private Double hour22;
 
   @Column(nullable = false)
-  private Integer hour23;
+  private Double hour23;
 
   @Builder
   public Statistics(Company company, LocalDateTime date, Integer powerOnCount,
       Double averageDailyPowerCount, Integer totalDrivingTime,
       Integer peakHour, Integer lowHour, Double averageOperationRate,
-      Integer hour00, Integer hour01, Integer hour02, Integer hour03,
-      Integer hour04, Integer hour05, Integer hour06, Integer hour07,
-      Integer hour08, Integer hour09, Integer hour10, Integer hour11,
-      Integer hour12, Integer hour13, Integer hour14, Integer hour15,
-      Integer hour16, Integer hour17, Integer hour18, Integer hour19,
-      Integer hour20, Integer hour21, Integer hour22, Integer hour23) {
+      Double hour00, Double hour01, Double hour02, Double hour03,
+      Double hour04, Double hour05, Double hour06, Double hour07,
+      Double hour08, Double hour09, Double hour10, Double hour11,
+      Double hour12, Double hour13, Double hour14, Double hour15,
+      Double hour16, Double hour17, Double hour18, Double hour19,
+      Double hour20, Double hour21, Double hour22, Double hour23) {
     this.company = company;
     this.date = date;
     this.powerOnCount = powerOnCount;
@@ -174,7 +174,7 @@ public class Statistics extends BaseEntity {
   }
 
   // 시간대별 가동률 업데이트 메서드
-  public void updateHourlyRates(int[] hourlyRates) {
+  public void updateHourlyRates(double[] hourlyRates) {
     if (hourlyRates != null && hourlyRates.length == StatisticConstants.HOURS_IN_DAY) {
       this.hour00 = hourlyRates[0];
       this.hour01 = hourlyRates[1];
@@ -204,12 +204,12 @@ public class Statistics extends BaseEntity {
   }
 
   // 안전한 값 반환
-  private Integer getSafeValue(Integer value) {
+  private Double getSafeValue(Double value) {
     return value != null ? value : StatisticConstants.DEFAULT_HOURLY_RATE;
   }
 
   // 특정 시간대 가동률 조회
-  public Integer getHourlyRate(int hour) {
+  public Double getHourlyRate(int hour) {
     if (hour < 0 || hour >= StatisticConstants.HOURS_IN_DAY) {
       return StatisticConstants.DEFAULT_HOURLY_RATE;
     }
@@ -246,8 +246,8 @@ public class Statistics extends BaseEntity {
   /**
    * 시간대별 가동률을 배열로 반환
    */
-  public Integer[] getHourlyRatesArray() {
-    return new Integer[]{
+  public Double[] getHourlyRatesArray() {
+    return new Double[]{
       hour00, hour01, hour02, hour03, hour04, hour05, hour06, hour07,
       hour08, hour09, hour10, hour11, hour12, hour13, hour14, hour15,
       hour16, hour17, hour18, hour19, hour20, hour21, hour22, hour23

--- a/src/main/java/org/thisway/statistics/service/StatisticCalculationService.java
+++ b/src/main/java/org/thisway/statistics/service/StatisticCalculationService.java
@@ -28,7 +28,7 @@ public class StatisticCalculationService {
      * 시간대별 가동률 계산
      * 공식: (시간 내 GPS 로그 개수) / (3600 * 업체 내 차량 대수) * 100
      */
-    public int[] calculateHourlyOperationRates(Long companyId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public double[] calculateHourlyOperationRates(Long companyId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         log.info("=== 시간대별 가동률 계산 시작 ===");
         log.info("회사 ID: {}, 시작 시간: {}, 종료 시간: {}", companyId, startDateTime, endDateTime);
 
@@ -38,7 +38,7 @@ public class StatisticCalculationService {
 
         if (vehicleCount == 0) {
             log.info("차량이 없어서 모든 시간대 가동률을 0으로 설정");
-            return new int[StatisticConstants.HOURS_IN_DAY];
+            return new double[StatisticConstants.HOURS_IN_DAY];
         }
 
         // 2. 시간대별 GPS 로그 개수 조회
@@ -46,7 +46,7 @@ public class StatisticCalculationService {
         log.info("시간대별 GPS 로그 개수: {}", hourlyGpsLogCounts);
 
         // 3. 시간대별 가동률 계산
-        int[] hourlyRates = new int[StatisticConstants.HOURS_IN_DAY];
+        double[] hourlyRates = new double[StatisticConstants.HOURS_IN_DAY];
         log.info("차량 대수: {}, 3600초: {}, 100%: {}", vehicleCount, StatisticConstants.SECONDS_IN_HOUR, StatisticConstants.PERCENTAGE_MULTIPLIER);
 
         for (int hour = 0; hour < StatisticConstants.HOURS_IN_DAY; hour++) {
@@ -55,7 +55,7 @@ public class StatisticCalculationService {
             // 가동률 = (GPS 로그 개수) / (3600 * 차량 대수) * 100 (퍼센트)
             double denominator = StatisticConstants.SECONDS_IN_HOUR * vehicleCount;
             double operationRate = (gpsLogCount.doubleValue() / denominator) * StatisticConstants.PERCENTAGE_MULTIPLIER;
-            hourlyRates[hour] = (int) operationRate;
+            hourlyRates[hour] = operationRate;
 
             log.info("시간 {}시: GPS 로그 {}개, 분모 {}, 가동률 {}% (소수점: {})",
                 hour, gpsLogCount, denominator, hourlyRates[hour], operationRate);
@@ -85,12 +85,12 @@ public class StatisticCalculationService {
     /**
      * 시간대별 가동률에서 피크 시간대 계산
      */
-    public Integer calculatePeakHourFromRates(int[] hourlyOperationRates) {
+    public Integer calculatePeakHourFromRates(double[] hourlyOperationRates) {
         int peakHour = StatisticConstants.DEFAULT_PEAK_HOUR;
-        int maxRate = 0;
+        double maxRate = 0;
 
         for (int hour = 0; hour < StatisticConstants.HOURS_IN_DAY; hour++) {
-            int rate = hourlyOperationRates[hour];
+            double rate = hourlyOperationRates[hour];
             if (rate > maxRate) {
                 maxRate = rate;
                 peakHour = hour;
@@ -103,13 +103,13 @@ public class StatisticCalculationService {
     /**
      * 시간대별 가동률에서 최소 시간대 계산
      */
-    public Integer calculateLowHourFromRates(int[] hourlyOperationRates) {
+    public Integer calculateLowHourFromRates(double[] hourlyOperationRates) {
         int lowHour = StatisticConstants.DEFAULT_LOW_HOUR;
-        int minRate = Integer.MAX_VALUE;
+        double minRate = 101;
         boolean foundNonZero = false;
 
         for (int hour = 0; hour < StatisticConstants.HOURS_IN_DAY; hour++) {
-            int rate = hourlyOperationRates[hour];
+            double rate = hourlyOperationRates[hour];
             
             // 0인 시간대는 제외하고 가장 낮은 값 찾기
             if (rate > 0 && rate < minRate) {
@@ -130,10 +130,10 @@ public class StatisticCalculationService {
     /**
      * 평균 가동률 계산 (시간대별 가동률의 평균)
      */
-    public Double calculateAverageOperationRate(int[] hourlyOperationRates) {
+    public Double calculateAverageOperationRate(double[] hourlyOperationRates) {
         double sum = 0.0;
         
-        for (int rate : hourlyOperationRates) {
+        for (double rate : hourlyOperationRates) {
             sum += rate;
         }
         

--- a/src/main/java/org/thisway/statistics/service/StatisticPersistenceService.java
+++ b/src/main/java/org/thisway/statistics/service/StatisticPersistenceService.java
@@ -49,7 +49,7 @@ public class StatisticPersistenceService {
         // 3. 통계 계산
         Long powerOnCount = calculationService.calculatePowerOnCount(companyId, startDateTime, endDateTime);
         Integer totalDrivingTime = calculationService.calculateTotalDrivingTime(companyId, startDateTime, endDateTime);
-        int[] hourlyOperationRates = calculationService.calculateHourlyOperationRates(companyId, startDateTime, endDateTime);
+        double[] hourlyOperationRates = calculationService.calculateHourlyOperationRates(companyId, startDateTime, endDateTime);
         Integer peakHour = calculationService.calculatePeakHourFromRates(hourlyOperationRates);
         Integer lowHour = calculationService.calculateLowHourFromRates(hourlyOperationRates);
         Double averageOperationRate = calculationService.calculateAverageOperationRate(hourlyOperationRates);

--- a/src/main/java/org/thisway/statistics/service/StatisticQueryService.java
+++ b/src/main/java/org/thisway/statistics/service/StatisticQueryService.java
@@ -11,13 +11,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thisway.common.CustomException;
-import org.thisway.common.ErrorCode;
 import org.thisway.statistics.constant.StatisticConstants;
 import org.thisway.statistics.dto.response.StatisticResponse;
 import org.thisway.statistics.entity.Statistics;
 import org.thisway.statistics.repository.StatisticsRepository;
-import org.thisway.triplog.dto.response.TripLocationStats;
+import org.thisway.triplog.dto.TripLocationRaw;
+import org.thisway.triplog.dto.TripLocationStats;
 import org.thisway.triplog.repository.TripLogRepository;
 
 @Slf4j
@@ -138,6 +137,13 @@ public class StatisticQueryService {
      */
     private List<TripLocationStats> getStartLocationStatBetweenDates(Long companyId, LocalDateTime startTime, LocalDateTime endTime) {
         log.info("출발지 통계 조회: 회사 ID {}, 시작 시간 {}, 종료 시간 {}", companyId, startTime, endTime);
-        return tripLogRepository.countGroupedByOnAddr(companyId, startTime, endTime);
+        List<TripLocationRaw> rawLocation = tripLogRepository.countGroupedByOnAddr(companyId, startTime, endTime);
+
+        long total = rawLocation.stream().mapToLong(TripLocationRaw::count).sum();
+
+        return rawLocation.stream()
+                .map(raw -> TripLocationStats.from(raw, total))
+                .limit(3)
+                .toList();
     }
 }

--- a/src/main/java/org/thisway/statistics/service/StatisticService.java
+++ b/src/main/java/org/thisway/statistics/service/StatisticService.java
@@ -1,14 +1,12 @@
 package org.thisway.statistics.service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thisway.statistics.dto.response.StatisticResponse;
-import org.thisway.triplog.dto.response.TripLocationStats;
 
 @Slf4j
 @Service

--- a/src/main/java/org/thisway/statistics/service/StatisticService.java
+++ b/src/main/java/org/thisway/statistics/service/StatisticService.java
@@ -20,15 +20,6 @@ public class StatisticService {
     private final StatisticQueryService queryService;
     
     /**
-     * 출발지 통계 조회
-     */
-    @Transactional(readOnly = true)
-    public List<TripLocationStats> getStartLocationStatBetweenDates(Long companyId, LocalDateTime startTime, LocalDateTime endTime) {
-        log.info("출발지 통계 조회 요청: 회사 ID {}, 시작 시간 {}, 종료 시간 {}", companyId, startTime, endTime);
-        return queryService.getStartLocationStatBetweenDates(companyId, startTime, endTime);
-    }
-    
-    /**
      * 통계 저장 (배치용)
      */
     public void saveStatistics(Long companyId, LocalDate targetDate) {

--- a/src/main/java/org/thisway/triplog/dto/TripLocationRaw.java
+++ b/src/main/java/org/thisway/triplog/dto/TripLocationRaw.java
@@ -1,0 +1,7 @@
+package org.thisway.triplog.dto;
+
+public record TripLocationRaw(
+        String addr,
+        Long count
+) {
+}

--- a/src/main/java/org/thisway/triplog/dto/TripLocationStats.java
+++ b/src/main/java/org/thisway/triplog/dto/TripLocationStats.java
@@ -1,0 +1,12 @@
+package org.thisway.triplog.dto;
+
+public record TripLocationStats(
+        String addr,
+        Long count,
+        Double rate
+) {
+    public static TripLocationStats from(TripLocationRaw tripLocationRaw, Long total) {
+        double rate = total > 0 ? tripLocationRaw.count() * 100.0 / total : 0.0;
+        return new TripLocationStats(tripLocationRaw.addr(), tripLocationRaw.count(), Math.round(rate * 100.0) / 100.0);
+    }
+}

--- a/src/main/java/org/thisway/triplog/dto/response/TripLocationStats.java
+++ b/src/main/java/org/thisway/triplog/dto/response/TripLocationStats.java
@@ -1,7 +1,0 @@
-package org.thisway.triplog.dto.response;
-
-public record TripLocationStats(
-        String addr,
-        Long count
-) {
-}

--- a/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
+++ b/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.thisway.triplog.dto.response.TripLocationStats;
+import org.thisway.triplog.dto.TripLocationRaw;
 import org.thisway.triplog.entity.TripLog;
 
 import java.time.LocalDateTime;
@@ -14,14 +14,15 @@ import java.util.List;
 public interface TripLogRepository extends JpaRepository<TripLog, Long> {
 
     @Query("""
-        SELECT new org.thisway.triplog.dto.response.TripLocationStats(t.onAddr, COUNT(t))
+        SELECT new org.thisway.triplog.dto.TripLocationRaw(t.onAddr, COUNT(t))
         FROM TripLog t
         WHERE t.vehicle.company.id = :companyId
             AND t.startTime >= :from
             AND t.startTime <= :to
         GROUP BY t.onAddr
+        ORDER BY COUNT(t) desc
     """)
-    List<TripLocationStats> countGroupedByOnAddr(
+    List<TripLocationRaw> countGroupedByOnAddr(
             @Param("companyId")Long companyId,
             @Param("from")LocalDateTime from,
             @Param("to")LocalDateTime to

--- a/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
+++ b/src/main/java/org/thisway/triplog/repository/TripLogRepository.java
@@ -53,7 +53,7 @@ public interface TripLogRepository extends JpaRepository<TripLog, Long> {
 
     // 특정 회사의 날짜 범위에 대한 총 운행시간을 분 단위로 계산
     @Query("SELECT t FROM TripLog t " +
-           "WHERE t.vehicle.company.id = :companyId " +
+           "WHERE t.vehicle.company.id = :companyId AND t.active = true " +
            "AND t.startTime >= :startDate AND t.startTime <= :endDate")
     List<TripLog> findTripLogsByCompanyAndDateRange(
             @Param("companyId") Long companyId,

--- a/src/main/java/org/thisway/triplog/service/TripLogServiceImpl.java
+++ b/src/main/java/org/thisway/triplog/service/TripLogServiceImpl.java
@@ -80,7 +80,7 @@ public class TripLogServiceImpl implements TripLogService {
             if (!gpsLogs.isEmpty()) {
                 return CurrentTripLogResponse.from(gpsLogs.getLast(), currentGpsLogs);
             } else {
-                throw new CustomException(ErrorCode.TRIP_LOG_NOT_FOUND);
+                return null;
             }
         } else {
             throw new CustomException(ErrorCode.VEHICLE_POWER_OFF);


### PR DESCRIPTION
### 📌 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 리팩토링

### 📌 관련 이슈
#197

### ✨ 반영 브랜치
refactor/197

### 📝 변경 사항
- [x] 통계 API 병합
- [x] 시동 위치 통계 백분율 추가
- [x] statistics hour 통계 double로 변경
- [x] 통계 생성 시 trip-log active false 인 경우는 포함하지 않도록 수정
- [x] 시간대별 통계 생성 시 total_trip_meter가 0인 경우는 포함하지 않도록 수정
### ➕ 추가 메모

### 🐛 테스트 결과 (테스트 결과가 있다면 넣어주세요)
<img width="1161" alt="스크린샷 2025-07-01 19 05 45" src="https://github.com/user-attachments/assets/0b1500e9-c51f-4c74-a806-e74c230eef0c" />

